### PR TITLE
Corrections

### DIFF
--- a/loopt.py
+++ b/loopt.py
@@ -25,7 +25,7 @@ JSON_TAG = 'viewer-loop'
 VALID_LOOP = voluptuous.schema_builder.Schema({
     'loops': {
         # loop name -> loop srcloc
-        str: srcloct.VALID_SRCLOC
+        voluptuous.schema_builder.Optional(str): srcloct.VALID_SRCLOC
     }
 }, required=True)
 

--- a/markup_code.py
+++ b/markup_code.py
@@ -3,6 +3,7 @@
 
 """Annotated source code."""
 
+import html
 import os
 import re
 
@@ -39,7 +40,7 @@ class Code:
 
         # load code into a string
         with open(os.path.join(root, path)) as source:
-            code = untabify_code(source.read())
+            code = html.escape(untabify_code(source.read()), quote=False)
 
         # split code into blocks of code, comments, and string literals
         blocks = split_code_into_blocks(code)

--- a/markup_trace.py
+++ b/markup_trace.py
@@ -3,6 +3,7 @@
 
 """Trace annotated with debugging information."""
 
+import html
 import os
 import re
 
@@ -65,7 +66,7 @@ class CodeSnippet:
         try:
             if path not in self.source:
                 with open(os.path.join(self.root, path)) as code:
-                    self.source[path] = code.read().splitlines()
+                    self.source[path] = html.escape(code.read()).splitlines()
         except FileNotFoundError:
             if srcloct.is_builtin(path): # <builtin-library-malloc>, etc.
                 return None

--- a/markup_trace.py
+++ b/markup_trace.py
@@ -95,10 +95,13 @@ class CodeSnippet:
 class Trace:
     """Trace annotated with debugging information."""
 
-    def __init__(self, name, trace, symbols, properties, snippets, outdir='.'):
+    def __init__(self, name, trace, symbols, properties, loops, snippets,
+                 outdir='.'):
         self.prop_name = name
         self.prop_desc = properties.get_description(name)
-        self.prop_srcloc = format_srcloc(properties.get_srcloc(name), symbols)
+        self.prop_srcloc = format_srcloc(properties.get_srcloc(name)
+                                         or loops.lookup_assertion(name),
+                                         symbols)
         self.steps = [{
             'kind': step['kind'],
             'num': num+1, # convert 0-based index to 1-based line number
@@ -136,6 +139,9 @@ class Trace:
 
 def format_srcloc(srcloc, symbols):
     """Format a source location for a trace step."""
+
+    if srcloc is None:
+        return 'Function none, File none, Line none'
 
     fyle, func, line = srcloc['file'], srcloc['function'], srcloc['line']
     func_srcloc = symbols.lookup(func)

--- a/report.py
+++ b/report.py
@@ -54,6 +54,6 @@ def report(config, sources, symbols, results, coverage, traces, properties,
     progress("Annotating traces")
     snippets = markup_trace.CodeSnippet(sources.root)
     for name, trace in traces.traces.items():
-        markup_trace.Trace(name, trace, symbols, properties, snippets).dump(
+        markup_trace.Trace(name, trace, symbols, properties, loops, snippets).dump(
             outdir=trace_dir)
     progress("Annotating traces", True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Jinja2 >= 2.11.2
+voluptuous >= 0.11.7

--- a/resultt.py
+++ b/resultt.py
@@ -259,8 +259,7 @@ class ResultFromCbmcText(Result):
                 if section == 'trace':
                     # trace module collects traces
                     continue
-                else:
-                    results[STATUS].append(line)
+                results[STATUS].append(line)
 
         return results
 

--- a/runt.py
+++ b/runt.py
@@ -38,7 +38,7 @@ def run(cmd, cwd=None, ignored=None, encoding=None):
     logging.debug('run: cmd: %s', cmd)
     logging.debug('run: kwds: %s', kwds)
 
-    result = subprocess.run(cmd, **kwds)
+    result = subprocess.run(cmd, **kwds, check=False)
 
     if result.returncode:
         logging.debug('Failed to run command: %s', ' '.join(cmd))

--- a/templates/link.jinja.html
+++ b/templates/link.jinja.html
@@ -1,21 +1,21 @@
 {% macro to_file(file_name, text, root='.') -%}
-    <a href="{{root}}/{{file_name}}.html">{{text}}</a>
+    <a href="{{root}}/{{file_name|e}}.html">{{text|e}}</a>
 {%- endmacro %}
 
 {% macro to_line(file_name, line_num, text, root='.') -%}
-    <a href="{{root}}/{{file_name}}.html#{{line_num}}">{{text}}</a>
+    <a href="{{root}}/{{file_name|e}}.html#{{line_num}}">{{text|e}}</a>
 {%- endmacro %}
 
 {% macro to_file_in_code(file_name, text, root='.') -%}
-    <a href="{{root}}/{{file_name}}.html" target="_code">{{text}}</a>
+    <a href="{{root}}/{{file_name|e}}.html" target="_code">{{text|e}}</a>
 {%- endmacro %}
 
 {% macro to_line_in_code(file_name, line_num, text, root='.') -%}
-    <a href="{{root}}/{{file_name}}.html#{{line_num}}" target="_code">{{text}}</a>
+    <a href="{{root}}/{{file_name|e}}.html#{{line_num}}" target="_code">{{text|e}}</a>
 {%- endmacro %}
 
 {% macro to_trace(trace_name, text='trace', root='.') -%}
-    <a href="{{root}}/traces/{{trace_name}}.html">{{text}}</a>
+    <a href="{{root}}/traces/{{trace_name|e}}.html">{{text|e}}</a>
 {%- endmacro %}
 
 {% macro to_viewer_css(root='.') -%}

--- a/templates/link.jinja.html
+++ b/templates/link.jinja.html
@@ -1,27 +1,43 @@
-{% macro to_file(file_name, text, root='.') -%}
-    <a href="{{root}}/{{file_name|e}}.html">{{text|e}}</a>
-{%- endmacro %}
+{%- macro to_file(file_name, text, root='.') -%}
+    {%- if file_name.startswith("<") and file_name.endswith(">") -%}
+        {{text|e}}
+    {%- else -%}
+        <a href="{{root}}/{{file_name|e}}.html">{{text|e}}</a>
+    {%- endif -%}
+{%- endmacro -%}
 
-{% macro to_line(file_name, line_num, text, root='.') -%}
-    <a href="{{root}}/{{file_name|e}}.html#{{line_num}}">{{text|e}}</a>
-{%- endmacro %}
+{%- macro to_line(file_name, line_num, text, root='.') -%}
+    {%- if file_name.startswith("<") and file_name.endswith(">") -%}
+        {{text|e}}
+    {%- else -%}
+        <a href="{{root}}/{{file_name|e}}.html#{{line_num}}">{{text|e}}</a>
+    {%- endif -%}
+{%- endmacro -%}
 
-{% macro to_file_in_code(file_name, text, root='.') -%}
-    <a href="{{root}}/{{file_name|e}}.html" target="_code">{{text|e}}</a>
-{%- endmacro %}
+{%- macro to_file_in_code(file_name, text, root='.') -%}
+    {%- if file_name.startswith("<") and file_name.endswith(">") -%}
+        {{text|e}}
+    {%- else -%}
+        <a href="{{root}}/{{file_name|e}}.html" target="_code">{{text|e}}</a>
+    {%- endif -%}
+{%- endmacro -%}
 
-{% macro to_line_in_code(file_name, line_num, text, root='.') -%}
-    <a href="{{root}}/{{file_name|e}}.html#{{line_num}}" target="_code">{{text|e}}</a>
-{%- endmacro %}
+{%- macro to_line_in_code(file_name, line_num, text, root='.') -%}
+    {%- if file_name.startswith("<") and file_name.endswith(">") -%}
+        {{text|e}}
+    {%- else -%}
+        <a href="{{root}}/{{file_name|e}}.html#{{line_num}}" target="_code">{{text|e}}</a>
+    {%- endif -%}
+{%- endmacro -%}
 
-{% macro to_trace(trace_name, text='trace', root='.') -%}
+{%- macro to_trace(trace_name, text='trace', root='.') -%}
     <a href="{{root}}/traces/{{trace_name|e}}.html">{{text|e}}</a>
-{%- endmacro %}
+{%- endmacro -%}
 
-{% macro to_viewer_css(root='.') -%}
-<link rel="stylesheet" type="text/css" href="{{root}}/viewer.css">
-{%- endmacro %}
+{%- macro to_viewer_css(root='.') -%}
+    <link rel="stylesheet" type="text/css" href="{{root}}/viewer.css">
+{%- endmacro -%}
 
-{% macro to_viewer_js(root='.') -%}
-<script type="text/javascript" src="{{root}}/viewer.js"></script>
-{%- endmacro %}
+{%- macro to_viewer_js(root='.') -%}
+    <script type="text/javascript" src="{{root}}/viewer.js"></script>
+{%- endmacro -%}

--- a/templates/summary.jinja.html
+++ b/templates/summary.jinja.html
@@ -86,12 +86,12 @@
         <li>Loop unwinding failures
           <ul>
             {% for error in errors.loop %}
-            <li> [{{link.to_trace(error.prop_name)}}]
-              {{error.prop_name}}
+            <li> [{{link.to_trace(error.loop_name)}}]
+              {{error.loop_name}}
               in line
               {{link.to_line(error.file_name, error.line_num, error.line_num)}}
               in file
-              {{link.to_file(error.file_name, error.line_num)}}
+              {{link.to_file(error.file_name, error.file_name)}}
             </li>
             {% endfor %}
           </ul>

--- a/templates/trace.jinja.html
+++ b/templates/trace.jinja.html
@@ -61,7 +61,7 @@
 
         <div id="step{{step.num}}" class="step">
         <div class="header">Step {{step.num}}: {{step.srcloc}}</div>
-        {% if code %}
+        {% if step.code %}
         <div class="code">{{step.code}}</div>
         {% endif %}
         <div class="cbmc">{{step.cbmc}}</div>

--- a/tracet.py
+++ b/tracet.py
@@ -94,7 +94,7 @@ VALID_TRACE = voluptuous.schema_builder.Schema(
 VALID_TRACES = voluptuous.schema_builder.Schema({
     'traces': {
         # failed property name -> failure trace
-        str : VALID_TRACE}
+        voluptuous.schema_builder.Optional(str): VALID_TRACE}
 }, required=True)
 
 ################################################################


### PR DESCRIPTION
This pull request fixes a number of mistakes.  Review this one commit at a time.

* Handle correctly name-mangled names of loops in static functions.
* Link correctly to loop unwinding assertion error traces.
* Allow the lists of loops and error traces to be empty.
* Manually escape characters rendered by jinja.
* Jinja trace template now correctly renders code snippets.
* Jinja templates no longer generate links to internal file names.
