### PR TITLE
Retain hidden function call/return pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ to implement cbmc-viewer):
 For all commands, the --help option prints detailed documentation of the
 command line arguments.
 
+## Installation
+
+This package requires python3:
+
+* On MacOS: brew install python3
+* On Ubuntu: sudo apt-get install python3
+* On Windows: download an installer from [www.python.org/downloads](https://www.python.org/downloads/)
+
+This package requires the jinja and voluptuous python packages:
+
+* python3 -m pip install -r requirements.txt
+
+This package works best with Exuberant Ctags installed (which is different from Emacs ctags often installed as both ctags and etags):
+
+* On MacOS: brew install ctags
+* On Ubuntu: sudo apt-get install ctags
+* On Windows: download a zip file from [ctags.sourceforge.net](http://ctags.sourceforge.net/)
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/filet.py
+++ b/filet.py
@@ -30,6 +30,7 @@ def filetype(filename):
     # Return the file type
     try:
         return {
+            'log': File.TEXT,
             'txt': File.TEXT,
             'jsn': File.JSON,
             'json': File.JSON,

--- a/markup_trace.py
+++ b/markup_trace.py
@@ -4,6 +4,7 @@
 """Trace annotated with debugging information."""
 
 import html
+import logging
 import os
 import re
 
@@ -58,9 +59,8 @@ class CodeSnippet:
         """A line of source code."""
 
         if line <= 0: # line numbers are 1-based
-            raise UserWarning(
-                "CodeSnippet lookup: line number not positive: {}".format(line)
-            )
+            logging.info("CodeSnippet lookup: line number not positive: %s", line)
+            return None
         line -= 1    # list indices are 0-based
 
         try:

--- a/optionst.py
+++ b/optionst.py
@@ -4,6 +4,7 @@
 """Command line options."""
 
 import logging
+import os
 import platform
 
 from sourcet import Sources
@@ -520,6 +521,12 @@ def defaults(args):
     args = default_source_method(args)
     args = default_tags_method(args)
     warn_against_using_text_for_cbmc_output(args)
+
+    if hasattr(args, 'srcdir'):
+        args.srcdir = os.path.abspath(args.srcdir)
+    if hasattr(args, 'wkdir'):
+        args.wkdir = os.path.abspath(args.wkdir)
+
     return args
 
 ################################################################

--- a/templates/summary.jinja.html
+++ b/templates/summary.jinja.html
@@ -24,7 +24,7 @@
           <th class="function">Function</th>
           <th class="file">File</th>
         </tr>
-        {% for func in function|sort(attribute="percentage", reverse=True)|sort(attribute="file_name,func_name") %}
+        {% for func in function|sort(attribute="file_name,func_name")|sort(attribute="percentage", reverse=True) %}
         <tr>
           <td class="coverage">{{'{:.2f}'.format(func.percentage)}} ({{func.hit}}/{{func.total}})</td>
           <td class="function">{{link.to_line(func.file_name, func.line_num, func.func_name)}}</td>


### PR DESCRIPTION
CBMC generates traces with builtin function calls visible and returns hidden.  This patch fixes this throwing away hidden steps in a trace, but retaining all function calls and returns to make trace rendering of  function calls work.  This is a temporary patch until https://github.com/diffblue/cbmc/issues/5413 is addressed.

This pull request also includes 4 other commits fixing small 5-line issues:
* Add installation tips to README.md
* Expand srcdir and wkdir args to absolute pathnames.
* Retain hidden function call/return pairs in traces
* Correct nested sorting in jinja summary template.
* Recognize *.log files as text files.
