### PR TITLE
Fix jinja sorting of coverage results.

### DIFF
--- a/cbmc_viewer/templates/summary.jinja.html
+++ b/cbmc_viewer/templates/summary.jinja.html
@@ -24,7 +24,7 @@
           <th class="function">Function</th>
           <th class="file">File</th>
         </tr>
-        {% for func in function|sort(attribute="file_name,func_name")|sort(attribute="percentage", reverse=True) %}
+        {% for func in function|sort(attribute="func_name")|sort(attribute="file_name")|sort(attribute="percentage", reverse=True) %}
         <tr>
           <td class="coverage">{{'{:.2f}'.format(func.percentage)}} ({{func.hit}}/{{func.total}})</td>
           <td class="function">{{link.to_line(func.file_name, func.line_num, func.func_name)}}</td>


### PR DESCRIPTION
This patch replaces the comma-separated shortcut `sort(attribute="attr1,attr2")` with the long form `sort(attribute="attr2")|sort(attribute="attr1")`. The shortcut used to work, but now fails with "No such attribute 'attr1,attr2'" in spite of the [sort documentation](https://jinja.palletsprojects.com/en/2.11.x/templates/#sort).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
