### PR TITLE
Improve symbol table parser

### DIFF
--- a/cbmc_viewer/symbol_table.py
+++ b/cbmc_viewer/symbol_table.py
@@ -13,8 +13,17 @@ from cbmc_viewer import srcloct
 def symbol_table(goto):
     """Extract symbol table from goto binary as lines of text."""
 
+    # The --show-symbol-table flag produces a sequence of symbol
+    # definitions.  Definitions are separated by blank lines.  Each
+    # definition is a sequence lines including
+    #
+    #   Symbol......: symbol
+    #   Pretty name.: symbol
+    #   Location....: file file_name line line_number
+
     cmd = ['cbmc', '--show-symbol-table', goto]
-    return runt.run(cmd).splitlines()
+    definitions = re.split(r'[\n\r][\n\r]+', runt.run(cmd))
+    return [definition.strip().splitlines() for definition in definitions]
 
 def is_symbol_line(line):
     """Line is a symbol table symbol definition line."""
@@ -26,23 +35,40 @@ def is_location_line(line):
 
     return line.startswith('Location')
 
+def is_pretty_name_line(line):
+    """Line is a symbol table symbol pretty name line."""
+
+    return line.startswith('Pretty name')
+
 def parse_symbol(sym):
-    """Symbol definition from symbol definition line."""
+    """Symbol name from symbol line."""
 
     if not is_symbol_line(sym):
         return None
 
-    match = re.match('.*: (tag-)?([a-zA-Z0-9_]*$)', sym)
-    if match is None:
-        return None
+    # Examples of symbol lines
+    # Symbol......: function_name
+    # Symbol......: function_name$link1
+    # Symbol......: function_name::parameter_name
+    # Symbol......: function_name::1::1::variable_name
+    # Symbol......: tag-struct_name
+    # Symbol......: tag-union_name
 
-    return match.group(2)
+    name = sym.strip().split()[-1]
+    match = re.match('^(tag-)?([a-zA-Z0-9_]+)$', name)
+    if match:
+        return match.group(2)
+    return None
 
 def parse_location(loc, wkdir):
-    """Symbol source location from symbol location line."""
+    """Symbol source location from location line."""
 
     if not is_location_line(loc):
         return None, None
+
+    # Examples lof location lines
+    # Location....:
+    # Location....: file file_name line line_number
 
     match = re.match('.* file (.*) line ([0-9]*)', loc)
     if match is None:
@@ -55,6 +81,59 @@ def parse_location(loc, wkdir):
 
     return abs_path, line
 
+def parse_pretty_name(sym):
+    """Symbols pretty name from pretty name line."""
+
+    if not is_pretty_name_line(sym):
+        return None
+
+    # Examples of pretty name lines
+    # Pretty name.:
+    # Pretty name.: function_name
+    # Pretty name.: function_name::1::1::variable_name
+    # Pretty name.: struct struct_name
+    # Pretty name.: union union_name
+
+    name = sym.strip().split()[-1]
+    if re.match('^[a-zA-Z0-9_]+$', name):
+        return name
+    return None
+
+def parse_symbol_table(definitions, wkdir):
+    """Extract symbols and source locations from symbol table definitions."""
+
+    def nonnull(items):
+        nonnull_items = [item for item in items if item is not None]
+        if nonnull_items:
+            return nonnull_items[0]
+        return None
+
+    def nonnull_pair(items):
+        nonnull_items = [item for item in items if item is not None
+                         and (item[0] is not None or item[1] is not None)]
+        if nonnull_items:
+            return nonnull_items[0]
+        return None, None
+
+    def symbol(dfn):
+        return nonnull([parse_symbol(line) for line in dfn])
+
+    def pretty(dfn):
+        return nonnull([parse_pretty_name(line) for line in dfn])
+
+    def location(dfn, wkdir):
+        return nonnull_pair([parse_location(line, wkdir) for line in dfn])
+
+    def parse_definition(dfn, wkdir):
+        loc = location(dfn, wkdir)
+        return {
+            'symbol': pretty(dfn) or symbol(dfn),
+            'file': loc[0],
+            'line': loc[1]
+        }
+
+    return [parse_definition(dfn, wkdir) for dfn in definitions]
+
 def source_files(goto, wkdir, srcdir=None):
     """Source files appearing in symbol table.
 
@@ -63,15 +142,13 @@ def source_files(goto, wkdir, srcdir=None):
     """
 
     wkdir = srcloct.abspath(wkdir)
-    srcdir = srcloct.abspath(srcdir) if srcdir is not None else None
+    srcs = [dfn['file']
+            for dfn in parse_symbol_table(symbol_table(goto), wkdir)]
+    srcs = [src for src in srcs if src and not srcloct.is_builtin(src)]
 
-    loc_lines = [line for line in symbol_table(goto) if is_location_line(line)]
-    locs = [parse_location(loc_line, wkdir) for loc_line in loc_lines]
-    paths = [path for path, _ in locs if path is not None]
-
-    srcs = [path for path in paths if not srcloct.is_builtin(path)]
-    if srcdir is not None:
-        srcs = [path for path in srcs if path.startswith(srcdir)]
+    if srcdir:
+        srcdir = srcloct.abspath(srcdir)
+        srcs = [src for src in srcs if src.startswith(srcdir)]
 
     return sorted(set(srcs))
 
@@ -84,39 +161,30 @@ def symbol_definitions(goto, wkdir, srcdir=None):
     """
 
     wkdir = srcloct.abspath(wkdir)
-    srcdir = srcloct.abspath(srcdir) if srcdir is not None else None
+    srcdir = srcloct.abspath(srcdir)
 
-    lines = [line for line in symbol_table(goto)
-             if is_symbol_line(line) or is_location_line(line)]
+    symbols = {}
+    for dfn in parse_symbol_table(symbol_table(goto), wkdir):
+        sym, src, num = dfn['symbol'], dfn['file'], dfn['line']
 
-    syms = {}
-    while lines:
-        try:
-            sym_line, loc_line = lines[0:2]
-            lines = lines[2:]
-        except ValueError:
-            raise UserWarning('Symbol table ended with umatched line: "{}"'
-                              .format(lines))
-
-        if not is_symbol_line(sym_line) or not is_location_line(loc_line):
-            raise UserWarning('Symbol table included unmatched lines: '
-                              '"{}" and "{}"'
-                              .format(sym_line, loc_line))
-
-        sym = parse_symbol(sym_line)
-        path, line = parse_location(loc_line, wkdir)
-        if sym is None or path is None or line is None:
+        if sym is None or src is None or num is None:
+            logging.info("Skipping symbol table entry: %s: %s, %s",
+                         sym, src, num)
             continue
-        if srcdir is not None and not path.startswith(srcdir):
+
+        if srcdir and not src.startswith(srcdir):
+            logging.info("Skipping symbol table entry: %s: %s, %s",
+                         sym, src, num)
             continue
-        sym_srcloc = srcloct.make_srcloc(path, None, line, wkdir, srcdir)
-        if sym in syms and sym_srcloc != syms[sym]:
+
+        srcloc = srcloct.make_srcloc(src, None, num, wkdir, srcdir)
+        if sym in symbols and srcloc != symbols[sym]:
             logging.warning("Skipping redefinition of symbol name: %s", sym)
             logging.warning("  Old symbol %s: file %s, line %s",
-                            sym, syms[sym]["file"], syms[sym]["line"])
+                            sym, symbols[sym]["file"], symbols[sym]["line"])
             logging.warning("  New symbol %s: file %s, line %s",
-                            sym, sym_srcloc["file"], sym_srcloc["line"])
+                            sym, srcloc["file"], srcloc["line"])
             continue
-        syms[sym] = sym_srcloc
+        symbols[sym] = srcloc
 
-    return syms
+    return symbols

--- a/cbmc_viewer/symbol_table.py
+++ b/cbmc_viewer/symbol_table.py
@@ -15,10 +15,10 @@ def symbol_table(goto):
 
     # The --show-symbol-table flag produces a sequence of symbol
     # definitions.  Definitions are separated by blank lines.  Each
-    # definition is a sequence lines including
+    # definition is a sequence of lines including
     #
-    #   Symbol......: symbol
-    #   Pretty name.: symbol
+    #   Symbol......: symbol_name
+    #   Pretty name.: simple_symbol_name
     #   Location....: file file_name line line_number
 
     cmd = ['cbmc', '--show-symbol-table', goto]
@@ -26,17 +26,17 @@ def symbol_table(goto):
     return [definition.strip().splitlines() for definition in definitions]
 
 def is_symbol_line(line):
-    """Line is a symbol table symbol definition line."""
+    """Line from symbol table defines a symbol name."""
 
     return line.startswith('Symbol.') # Match Symbol. not Symbols:
 
 def is_location_line(line):
-    """Line is a symbol table symbol location line."""
+    """Line from symbol table defines a location of a symbol definition."""
 
     return line.startswith('Location')
 
 def is_pretty_name_line(line):
-    """Line is a symbol table symbol pretty name line."""
+    """Line from symbol table defines a simple symbol name (a pretty name)."""
 
     return line.startswith('Pretty name')
 
@@ -66,7 +66,7 @@ def parse_location(loc, wkdir):
     if not is_location_line(loc):
         return None, None
 
-    # Examples lof location lines
+    # Examples of location lines (may be no location for symbol)
     # Location....:
     # Location....: file file_name line line_number
 
@@ -87,7 +87,7 @@ def parse_pretty_name(sym):
     if not is_pretty_name_line(sym):
         return None
 
-    # Examples of pretty name lines
+    # Examples of pretty name lines (may be no pretty name for symbol)
     # Pretty name.:
     # Pretty name.: function_name
     # Pretty name.: function_name::1::1::variable_name

--- a/cbmc_viewer/symbolt.py
+++ b/cbmc_viewer/symbolt.py
@@ -173,7 +173,7 @@ class SymbolFromCtags(Symbol):
     list of files.
     """
 
-    # Warning: ctags by default accepts only certain file extensions
+    # TODO: ctags by default accepts only certain file extensions
     # like .c and .h as source files.  Files with other extensions
     # like .inl are currently ignored, but consider using the ctags
     # options −−list−maps and −−langmap.

--- a/cbmc_viewer/symbolt.py
+++ b/cbmc_viewer/symbolt.py
@@ -173,6 +173,11 @@ class SymbolFromCtags(Symbol):
     list of files.
     """
 
+    # Warning: ctags by default accepts only certain file extensions
+    # like .c and .h as source files.  Files with other extensions
+    # like .inl are currently ignored, but consider using the ctags
+    # options −−list−maps and −−langmap.
+
     def __init__(self, root, files):
         super(SymbolFromCtags, self).__init__(
             self.build_symbol_table(


### PR DESCRIPTION
Symbols are recorded in the symbol table with a mangled name and a pretty name.  Most cbmc output uses the pretty name, so modify the symbol table parser to use the pretty name for a symbol if it exists. 

Also clean up the symbol table parser to break the cbmc symbol table output into a sequence of definitions and then break each definition into a sequence of lines.  The prior implementation just scanned the cbmc output as a sequence of lines, which made grouping symbol names and locations ad hoc and error prone.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
