### PR TITLE
Restrict coverage to source files under the source root.

### DIFF
--- a/cbmc_viewer/coveraget.py
+++ b/cbmc_viewer/coveraget.py
@@ -193,9 +193,6 @@ class Coverage:
 def merge_coverage_data(coverage_list):
     """Merge sets of coverage data"""
 
-    if len(coverage_list) == 1:
-        return coverage_list[0]
-
     coverage = {}
     for coverage_data in coverage_list:
         if not coverage_data:
@@ -204,6 +201,15 @@ def merge_coverage_data(coverage_list):
 
         # file name -> function data
         for filename, function_data in coverage_data.items():
+
+            # The source locations produced by srcloct have paths
+            # relative to the source root for all files under the
+            # root, and have absolute paths for all other files.
+            if filename.startswith('/'):
+                logging.info("Restricting coverage to files under the source "
+                             "root: skipping %s", filename)
+                continue
+
             coverage[filename] = coverage.get(filename, {})
             # function -> line data
             for func, line_data in function_data.items():


### PR DESCRIPTION
The MacOS header file `_ctype.h` contains inlined function
definitions, and cbmc coverage data can include coverage data for
these functions.  Since we don't generally care about coverage of
system code, and since we don't generally have easy access to source
code for system calls, we omit this code from the coverage
calculations.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
