### PR TITLE
Fix code snippets, refresh pip setup.py

### DIFF
--- a/cbmc_viewer/markup_trace.py
+++ b/cbmc_viewer/markup_trace.py
@@ -66,7 +66,7 @@ class CodeSnippet:
         try:
             if path not in self.source:
                 with open(os.path.join(self.root, path)) as code:
-                    self.source[path] = html.escape(code.read()).splitlines()
+                    self.source[path] = code.read().splitlines()
         except FileNotFoundError:
             if srcloct.is_builtin(path): # <builtin-library-malloc>, etc.
                 return None
@@ -77,13 +77,13 @@ class CodeSnippet:
         # return the whole statement which may be broken over several lines
         snippet = ' '.join(self.source[path][line:line+5])
         snippet = re.sub(r'\s+', ' ', snippet).strip()
-        idx = snippet.find(';') # end of statement
+        idx = snippet.find(';')     # end of statement
         if idx >= 0:
-            return snippet[:idx+1]
-        idx = snippet.find('}') # end of block
+            return html.escape(snippet[:idx+1])
+        idx = snippet.find('}')     # end of block
         if idx >= 0:
-            return snippet[:idx+1]
-        return snippet          # statement extends over more that 5 lines
+            return html.escape(snippet[:idx+1])
+        return html.escape(snippet) # statement extends over more that 5 lines
 
 
     def lookup_srcloc(self, srcloc):

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,15 @@ setuptools.setup(
     description="A CBMC viewer",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/pypa/sampleproject",
+    url="https://github.com/awslabs/aws-viewer-for-cbmc",
     packages=setuptools.find_packages(),
+    license="Apache License 2.0",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     install_requires=[
         "jinja2",
         "setuptools",


### PR DESCRIPTION
First select the code snippet (eg, code up to the `;` ending the current statement) and then escape html characters (eg, replace `>` with `&gt;`).  Prior version escaped characters then selected the code snippet, truncating lines prematurely (eg, truncanting at `&gt;` or `>`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
