### PR TITLE
CBMC runtime analysis: Record array constraints added during CBMC post processing

### DIFF
--- a/cbmc_viewer/arrayt.py
+++ b/cbmc_viewer/arrayt.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CBMC Array Constraints.
+
+This module displays count of different types of array constraints
+added during postprocessing.
+Inputs to the module is a json file obtained by running CBMC with the
+--show-array-constraints parse option and the project reporting
+directory.
+"""
+import logging
+
+import voluptuous
+import voluptuous.humanize
+
+from cbmc_viewer import filet
+from cbmc_viewer import parse
+from cbmc_viewer import templates
+from cbmc_viewer import util
+
+################################################################
+
+VALID_CONSTRAINT = voluptuous.schema_builder.Schema({
+    str: int # example: arrayWith, arrayAckermann
+    })
+
+VALID_ARRAY_CONSTRAINTS = voluptuous.schema_builder.Schema({
+    'arrayConstraints': VALID_CONSTRAINT,
+    'numOfConstraints': int
+    },required=True)
+
+VALID_SUMMARY = voluptuous.schema_builder.Schema({
+    'summary': VALID_ARRAY_CONSTRAINTS
+    },required=True)
+
+################################################################
+
+class ArrayConstraintSummary:
+
+    def __init__(self, json_file):
+        self.summary = do_make_array_constraint(json_file)
+        self.validate()
+
+    def __str__(self):
+        """Render the array constraint summary as html."""
+        return templates.render_array_constraint_summary(self.summary)
+
+    def validate(self):
+        """Validate members of a summary object."""
+
+        return voluptuous.humanize.validate_with_humanized_errors(
+            self.__dict__, VALID_SUMMARY
+        )
+
+    def dump(self, filename=None, outdir='.'):
+        """Write the array constraint summary to a file rendered as html."""
+
+        util.dump(self, filename or "array.html", outdir)
+
+################################################################
+# Json key tags to access elements in cbmc json output
+
+JSON_ARRAY_CONSTRAINTS_KEY = 'arrayConstraints'
+
+################################################################
+# Utility functions to generate array constraint summary
+
+def get_array_constraint_metrics(json_file):
+    summary = {}
+
+    json_data = parse.parse_json_file(json_file)
+    for item in json_data:
+        if JSON_ARRAY_CONSTRAINTS_KEY in item.keys():
+            array_constraints_item = item
+            summary.update(array_constraints_item)
+            break
+
+    if not summary:
+        summary = {
+            'arrayConstraints': {},
+            'numOfConstraints': 0
+        }
+
+    return summary
+
+def fail(msg):
+    """Log failure and raise exception."""
+
+    logging.info(msg)
+    raise UserWarning(msg)
+
+def do_make_array_constraint(cbmc_array_constraint):
+    if cbmc_array_constraint:
+        if filet.is_json_file(cbmc_array_constraint):
+            return get_array_constraint_metrics(cbmc_array_constraint)
+        fail("Expected json file: {}"
+             .format(cbmc_array_constraint))

--- a/cbmc_viewer/doc/make-array.md
+++ b/cbmc_viewer/doc/make-array.md
@@ -1,0 +1,23 @@
+# Name
+
+make-array -- list count and type of array constraints added during CBMC postprocessing
+
+# Synopsis
+
+	usage: make-array [-h] [--array FILE] [--reportdir REPORTDIR] 
+                      [--verbose] [--debug]
+
+# Description
+
+This is a front end for the arrayt module that viewer uses to scan
+the results of cbmc array constraint metric collection. The output 
+is a json file that describes the type and count of array constraints
+added by cbmc during postprocessing.
+
+Simple uses of make-array are
+
+    # Generate the array constraint data from output of "cbmc --show-array-constraints"
+    # cbmc --show-array-constraints --json-ui program.goto > array.json
+    make-array --array array.json --reportdir html_report_dir
+
+Type "make-array --help" for a complete list of command line options.

--- a/cbmc_viewer/make_array.py
+++ b/cbmc_viewer/make_array.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- mode: python-mode -*-
+
+"""List CBMC array constraint metrics."""
+
+
+import argparse
+import sys
+
+from cbmc_viewer import arrayt
+from cbmc_viewer import optionst
+
+def create_parser():
+    """Command line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="List CBMC array constraint metrics."
+    )
+
+    optionst.array(parser)
+    optionst.reportdir(parser)
+
+    optionst.log(parser)
+
+    return parser
+
+################################################################
+
+def main():
+    """List CBMC array constraint metrics."""
+
+    args = create_parser().parse_args()
+    args = optionst.defaults(args)
+
+    try:
+        array = arrayt.ArrayConstraintSummary(args.array)
+        array.dump(outdir=args.reportdir)
+    except UserWarning as error:
+        sys.exit(error)
+
+if __name__ == "__main__":
+    main()

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -114,6 +114,22 @@ def property(parser):
     )
     return parser
 
+def array(parser):
+    'Define --array command line option.'
+
+    parser.add_argument(
+        '--array',
+        metavar='FILE',
+        default='array.json',
+        help="""
+        CBMC array constraints added during postprocessing.
+        A json file containing the output of
+        'cbmc --show-array-constraints'.
+        (Default: %(default)s)
+        """
+    )
+    return parser
+
 def exclude(parser):
     'Define --exclude command line option.'
 

--- a/cbmc_viewer/report.py
+++ b/cbmc_viewer/report.py
@@ -23,7 +23,7 @@ def progress_default(string):
     logging.info(string)
 
 def report(config, sources, symbols, results, coverage, traces, properties,
-           loops, report_dir='.', progress=progress_default):
+           loops, array, report_dir='.', progress=progress_default):
     """Assemble the full report for cbmc viewer."""
 
     # The report is assembled from many sources of data
@@ -60,3 +60,7 @@ def report(config, sources, symbols, results, coverage, traces, properties,
         markup_trace.Trace(name, trace, symbols, properties, loops, snippets).dump(
             outdir=trace_dir)
     progress("Annotating traces", True)
+
+    progress("Preparing array constraint summary report")
+    array.dump(outdir=report_dir)
+    progress("Preparing array constraint summary report", True)

--- a/cbmc_viewer/templates.py
+++ b/cbmc_viewer/templates.py
@@ -14,6 +14,9 @@ SUMMARY_TEMPLATE = 'summary.jinja.html'
 CODE_TEMPLATE = 'code.jinja.html'
 TRACE_TEMPLATE = 'trace.jinja.html'
 
+# runtime analysis metrics
+ARRAY_CONSTRAINT_SUMMARY_TEMPLATE = 'array.jinja.html'
+
 ENV = None
 
 def env():
@@ -48,4 +51,11 @@ def render_trace(name, desc, srcloc, steps):
 
     return env().get_template(TRACE_TEMPLATE).render(
         prop_name=name, prop_desc=desc, prop_srcloc=srcloc, steps=steps
+    )
+
+def render_array_constraint_summary(array_constraint_summary):
+    """Render array constraint summary as html."""
+
+    return env().get_template(ARRAY_CONSTRAINT_SUMMARY_TEMPLATE).render(
+        summary=array_constraint_summary
     )

--- a/cbmc_viewer/templates/array.jinja.html
+++ b/cbmc_viewer/templates/array.jinja.html
@@ -1,0 +1,24 @@
+
+<html>
+  <head>
+    <title>CBMC</title>
+    <style>
+      .array_constr
+      {
+        padding-bottom: 1em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>CBMC Array Theory Constraints Report</h1>
+    <p>
+      Total number of constraints: {{summary.numOfConstraints}}
+    </p>
+    <div class="array_summary">
+      {% for key in summary.arrayConstraints.keys() %}
+        <p>{{key}} : {{summary.arrayConstraints[key]}}</p>
+      {% endfor %}  
+    </div>
+  </body>
+</html>

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -10,6 +10,7 @@ and with lists of property violations and traces for each violation.
 
 import argparse
 import datetime
+import json
 import logging
 import os
 
@@ -25,6 +26,9 @@ from cbmc_viewer import sourcet
 from cbmc_viewer import symbolt
 from cbmc_viewer import tracet
 
+# runtime analysis metrics
+from cbmc_viewer import arrayt
+
 def create_parser():
     """Create the command line parser."""
 
@@ -39,6 +43,9 @@ def create_parser():
     optionst.result(cbmc_data)
     optionst.coverage(cbmc_data)
     optionst.property(cbmc_data)
+
+    # runtime analysis metrics
+    optionst.array(cbmc_data)
 
     proof_sources = parser.add_argument_group('Sources')
     optionst.srcdir(proof_sources)
@@ -209,8 +216,13 @@ def viewer():
     dump(symbols, 'viewer-symbol.json')
     progress("Preparing symbol table", True)
 
+    progress("Scanning array constraint data")
+    array = arrayt.ArrayConstraintSummary(args.array)
+    dump(json.dumps(array.summary, indent=2), 'viewer-array.json')
+    progress("Scanning array constraint data", True)
+
     config = configt.Config(args.config)
     report.report(config, sources, symbols, results, coverage, traces,
-                  properties, loops, htmldir, progress)
+                  properties, loops, array, htmldir, progress)
 
     global_progress("CBMC viewer", True)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setuptools.setup(
             "make-result = cbmc_viewer.make_result:main",
             "make-source = cbmc_viewer.make_source:main",
             "make-symbol = cbmc_viewer.make_symbol:main",
-            "make-trace = cbmc_viewer.make_trace:main"
+            "make-trace = cbmc_viewer.make_trace:main",
+            "make-array = cbmc_viewer.make_array:main"
         ]
     }
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Displays the type and count of array constraints being added during post processing. Often has a direct correlation to the post processing runtime. Takes json output obtained from cbmc --show-array-constraints, and generates html report for the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
