### PR TITLE
Allow property list to be empty

### DIFF
--- a/cbmc_viewer/propertyt.py
+++ b/cbmc_viewer/propertyt.py
@@ -35,7 +35,7 @@ VALID_PROPERTY_DEFINITION = voluptuous.schema_builder.Schema({
 VALID_PROPERTY = voluptuous.schema_builder.Schema({
     'properties': {
         # property name -> property definition
-        str: VALID_PROPERTY_DEFINITION
+        voluptuous.schema_builder.Optional(str): VALID_PROPERTY_DEFINITION
     }
 }, required=True)
 


### PR DESCRIPTION
Modify the voluptuous schema for the property object to allow the list of properties to be empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
