### PR TITLE
Skip loop heads and strip warning prefixes

### DIFF
--- a/cbmc_viewer/markup_summary.py
+++ b/cbmc_viewer/markup_summary.py
@@ -148,9 +148,17 @@ def function_coverage(coverage, symbols):
 def warnings(results):
     """Proof warnings."""
 
-    prefix = "**** WARNING:"
-    length = len(prefix)
-    return [warning[length:].strip() for warning in results.warning]
+    prefixes = ["**** WARNING:", "warning:"]
+
+    def strip_prefixes(string, prefixes):
+        """Strip warning prefixes from a warning string."""
+
+        for prefix in prefixes:
+            if string.startswith(prefix):
+                return string[len(prefix):].strip()
+        return string
+
+    return [strip_prefixes(warning, prefixes) for warning in results.warning]
 
 def missing_functions(messages):
     """Names of missing functions."""

--- a/cbmc_viewer/tracet.py
+++ b/cbmc_viewer/tracet.py
@@ -345,6 +345,12 @@ def parse_xml_step(step, root=None):
               parse_xml_location_only if kind == 'location-only' else None)
 
     if parser is None:
+        # skip uninteresting kinds of steps
+        if kind in ['loop-head']:
+            logging.debug('Skipping step type: %s', kind)
+            return None
+
+        # warn about skipping a potentially interesting kind of step
         logging.warning('Skipping step type: %s', kind)
         return None
 


### PR DESCRIPTION
Silently skip loop-head steps in error traces: CBMC has added new kinds of steps to error traces, and the loop-head step is not interesting to us, so we silently skip over loop-head steps.

Correctly strip warning prefixes from warnings produced by CBMC: CBMC used to preface all warnings with the string "**** WARNING:" but CBMC now also uses "warning:".  This patch is more careful about what prefix it removes from warning messages.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
