### PR TITLE
Fix property sorting key

### DIFF
--- a/cbmc_viewer/coveraget.py
+++ b/cbmc_viewer/coveraget.py
@@ -171,7 +171,8 @@ class Coverage:
                 return {key: serialize(val) for key, val in data.items()}
             return data
 
-        return json.dumps({JSON_TAG: serialize(self.__repr__())}, indent=2)
+        return json.dumps({JSON_TAG: serialize(self.__repr__())}, indent=2,
+                          sort_keys=True)
 
     def validate(self):
         """Validate coverage."""

--- a/cbmc_viewer/propertyt.py
+++ b/cbmc_viewer/propertyt.py
@@ -48,8 +48,9 @@ def key(name):
         dot = name.rindex('.')
         return (name[:dot].lower(), int(name[dot+1:]))
     except ValueError:
-        logging.info("Property name missing a separating period: %s", name)
-        return None
+        logging.warning("Property name not of the form STRING.INTEGER: %s",
+                        name)
+        return (name, 0)
 
 ################################################################
 


### PR DESCRIPTION
Property names usually has the form file.function.integer, and property names are sorted using the key (file.function, integer).  Recursion unwinding properties sometimes have the form file.function.recursion.  This patch uses the sorting key (file.function.recursion, 0) for unusual property names like this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
