### PR TITLE
Correct the parsing of source locations in the textual output of cbmc.

### DIFF
--- a/cbmc_viewer/srcloct.py
+++ b/cbmc_viewer/srcloct.py
@@ -147,20 +147,22 @@ def text_srcloc(cbmc_srcloc, wkdir=None, root=None):
 
     # Source locations appear in many forms in text output
 
+    # Source location in a step
     match = re.search('file (.+) function (.+) line ([0-9]+)', cbmc_srcloc)
     if match:
         path, func, line = match.groups()[:3]
         return make_srcloc(path, func, line, wkdir, root)
 
+    # Source location in an assumption
     match = re.search('file (.+) line ([0-9]+) function (.+)', cbmc_srcloc)
     if match:
         path, line, func = match.groups()[:3]
         return make_srcloc(path, func, line, wkdir, root)
 
-    # Some models of intrinsic functions omit file and line
-    match = re.search('function (.+)', cbmc_srcloc)
+    # Source location in an intrinsic step may omit file and line
+    match = re.search('function (.+) thread', cbmc_srcloc)
     if match:
-        path, func, line = '<intrinsic>', match.groups(0), 0
+        path, func, line = '<intrinsic>', match.group(1), 0
         return make_srcloc(path, func, line, wkdir, root)
 
     logging.info("Source location missing in text output: %s", cbmc_srcloc)


### PR DESCRIPTION
In a trace in the textual output of cbmc, the source location for an intrinsic function like the gcc atomic built-in functions may include only the function name and may omit the file name and line number.

This patch corrects the parsing of such source locations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
