### PR TITLE
Extend CBMC Viewer to work with RBMC

### DIFF
--- a/cbmc_viewer/markup_summary.py
+++ b/cbmc_viewer/markup_summary.py
@@ -134,7 +134,7 @@ def function_coverage(coverage, symbols):
             'total': func_cov['total'],
             'file_name': file_name,
             'func_name': func_name,
-            'line_num': symbols.lookup(func_name)["line"]
+            'line_num': symbols.lookup(func_name).get("line") if symbols.lookup(func_name) else 0
         }
         for file_name, file_data in coverage.function_coverage.items()
         for func_name, func_cov in file_data.items()
@@ -206,7 +206,7 @@ def property_definition(prop_name, properties, symbols):
         'prop_name': prop_name,
         'prop_desc': prop_def['description'],
         'file_name': srcloc['file'],
-        'func_name': srcloc['function'],
+        'func_name': srcloc['function'] or '',
         'line_num': srcloc['line'],
         'func_line':
             # Symbol table won't contain functions modeled by CBMC (eg, strcmp)

--- a/cbmc_viewer/reachablet.py
+++ b/cbmc_viewer/reachablet.py
@@ -130,7 +130,7 @@ def parse_cbmc_json(json_data, root):
     reachable = {}
     for function in json_data:
         func_name = function['function']
-        file_name = srcloct.abspath(function['file name'])
+        file_name = srcloct.abspath(function['file'])
 
         if func_name.startswith('__CPROVER'):
             continue

--- a/cbmc_viewer/reachablet.py
+++ b/cbmc_viewer/reachablet.py
@@ -130,10 +130,16 @@ def parse_cbmc_json(json_data, root):
     reachable = {}
     for function in json_data:
         func_name = function['function']
-        file_name = srcloct.abspath(function['file'])
-
         if func_name.startswith('__CPROVER'):
             continue
+
+        file_name = function.get('file')
+        if file_name is None:
+            logging.error('Skipping reachable function with invalid source location: %s',
+                          function)
+            continue
+
+        file_name = srcloct.abspath(file_name)
         if srcloct.is_builtin(file_name):
             continue
         if not file_name.startswith(root):

--- a/cbmc_viewer/runt.py
+++ b/cbmc_viewer/runt.py
@@ -34,7 +34,7 @@ def run(cmd, cwd=None, ignored=None, encoding=None):
     if sys.version_info >= (3, 6):
         kwds['encoding'] = encoding
 
-    logging.debug('run: cmd: %s', cmd)
+    logging.debug('run: cmd: %s', ' '.join(cmd))
     logging.debug('run: kwds: %s', kwds)
 
     result = subprocess.run(cmd, **kwds, check=False)

--- a/cbmc_viewer/symbolt.py
+++ b/cbmc_viewer/symbolt.py
@@ -34,7 +34,7 @@ class Tags(enum.Enum):
 VALID_SYMBOL = voluptuous.schema_builder.Schema({
     'symbols': {
         # symbol name -> symbol srcloc
-        str : srcloct.VALID_SRCLOC
+        voluptuous.schema_builder.Optional(str) : srcloct.VALID_SRCLOC
     }
 }, required=True)
 


### PR DESCRIPTION
The current implementation of the RMC model checker for Rust provides some incomplete information that viewer depends on .  This pull request makes a few changes to handle the missing information, mostly by providing placeholders for the data until it is produced.

This pull request also makes one change to reachable.py to handle a change in the json output of goto-analyzer.  It changes a key name from 'file name' to 'file' in the line 
```
    file_name = function.get('file')
```