### PR TITLE
Run pylint

### DIFF
--- a/cbmc_viewer/coveraget.py
+++ b/cbmc_viewer/coveraget.py
@@ -224,7 +224,7 @@ def merge_coverage_data(coverage_list):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.error.Error as error:
-        raise UserWarning("Error merging coverage data: {}".format(error))
+        raise UserWarning("Error merging coverage data: {}".format(error)) from error
     return coverage
 
 
@@ -294,7 +294,7 @@ class CoverageFromJson(Coverage):
     """CBMC coverage results from make-coverage"""
 
     def __init__(self, json_files):
-        super(CoverageFromJson, self).__init__(
+        super().__init__(
             [load_json(json_file) for json_file in json_files]
         )
 
@@ -310,8 +310,9 @@ def load_json(json_file):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.error.Error as error:
-        raise UserWarning("Error loading json coverage data: {}: {}"
-                          .format(json_file, error))
+        raise UserWarning(
+            "Error loading json coverage data: {}: {}".format(json_file, error)
+        ) from error
     return coverage
 
 def repair_json(coverage):
@@ -342,7 +343,7 @@ class CoverageFromCbmcJson(Coverage):
 
     def __init__(self, json_files, root):
         root = srcloct.abspath(root)
-        super(CoverageFromCbmcJson, self).__init__(
+        super().__init__(
             [load_cbmc_json(json_file, root) for json_file in json_files]
         )
 
@@ -373,8 +374,9 @@ def load_cbmc_json(json_file, root):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.error.Error as error:
-        raise UserWarning("Error loading cbmc json coverage data: {}: {}"
-                          .format(json_file, error))
+        raise UserWarning(
+            "Error loading cbmc json coverage data: {}: {}".format(json_file, error)
+        ) from error
     return coverage
 
 ################################################################
@@ -386,7 +388,7 @@ class CoverageFromCbmcXml(Coverage):
 
     def __init__(self, xml_files, root):
         root = srcloct.abspath(root)
-        super(CoverageFromCbmcXml, self).__init__(
+        super().__init__(
             [load_cbmc_xml(xml_file, root) for xml_file in xml_files]
         )
 
@@ -410,8 +412,9 @@ def load_cbmc_xml(xml_file, root):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.error.Error as error:
-        raise UserWarning("Error loading cbmc xml coverage data: {}: {}"
-                          .format(xml_file, error))
+        raise UserWarning(
+            "Error loading cbmc xml coverage data: {}: {}".format(xml_file, error)
+        ) from error
     return coverage
 
 ################################################################

--- a/cbmc_viewer/filet.py
+++ b/cbmc_viewer/filet.py
@@ -55,16 +55,16 @@ def is_xml_file(xml):
 
 def all_text_files(txts):
     """Files are text files."""
-    return all([is_text_file(txt) for txt in txts])
+    return all(is_text_file(txt) for txt in txts)
 def all_json_files(jsons):
     """Files are json files."""
-    return all([is_json_file(json) for json in jsons])
+    return all(is_json_file(json) for json in jsons)
 def all_xml_files(xmls):
     """Files are xml files."""
-    return all([is_xml_file(xml) for xml in xmls])
+    return all(is_xml_file(xml) for xml in xmls)
 
 def any_text_files(txts):
     """Any of the files are text files."""
-    return any([is_text_file(txt) for txt in txts])
+    return any(is_text_file(txt) for txt in txts)
 
 ################################################################

--- a/cbmc_viewer/loopt.py
+++ b/cbmc_viewer/loopt.py
@@ -156,7 +156,7 @@ class LoopFromJson(Loop):
 
     def __init__(self, json_files):
 
-        super(LoopFromJson, self).__init__(
+        super().__init__(
             [parse.parse_json_file(json_file, fail=True)[JSON_TAG]['loops']
              for json_file in json_files]
         )
@@ -168,7 +168,7 @@ class LoopFromCbmcJson(Loop):
 
     def __init__(self, json_files, root):
 
-        super(LoopFromCbmcJson, self).__init__(
+        super().__init__(
             [load_cbmc_json(json_file, root) for json_file in json_files]
         )
 
@@ -199,7 +199,7 @@ class LoopFromCbmcXml(Loop):
 
     def __init__(self, xml_files, root):
 
-        super(LoopFromCbmcXml, self).__init__(
+        super().__init__(
             [load_cbmc_xml(xml_file, root) for xml_file in xml_files]
         )
 
@@ -226,15 +226,17 @@ class LoopFromGoto(Loop):
 
         cmd = ['cbmc', '--show-loops', '--json-ui', goto]
         try:
-            super(LoopFromGoto, self).__init__(
+            super().__init__(
                 [parse_cbmc_json(json.loads(runt.run(cmd, cwd=cwd)), root)]
             )
         except subprocess.CalledProcessError as err:
-            raise UserWarning('Failed to run {}: {}'
-                              .format(cmd, str(err)))
+            raise UserWarning(
+                'Failed to run {}: {}' .format(cmd, str(err))
+            ) from err
         except json.decoder.JSONDecodeError as err:
-            raise UserWarning('Failed to parse output of {}: {}'
-                              .format(cmd, str(err)))
+            raise UserWarning(
+                'Failed to parse output of {}: {}'.format(cmd, str(err))
+            ) from err
 
 ################################################################
 # make-loop

--- a/cbmc_viewer/markup_summary.py
+++ b/cbmc_viewer/markup_summary.py
@@ -173,7 +173,7 @@ def expected_missing_functions(results, config):
 
     return [
         function for function in missing_functions(warnings(results))
-        if function in config.expected_missing_functions() or []
+        if function in config.expected_missing_functions()
     ]
 
 def unexpected_missing_functions(results, config):
@@ -181,7 +181,7 @@ def unexpected_missing_functions(results, config):
 
     return [
         function for function in missing_functions(warnings(results))
-        if function not in config.expected_missing_functions() or []
+        if function not in config.expected_missing_functions()
     ]
 
 def other_warnings(results):

--- a/cbmc_viewer/markup_trace.py
+++ b/cbmc_viewer/markup_trace.py
@@ -67,12 +67,12 @@ class CodeSnippet:
             if path not in self.source:
                 with open(os.path.join(self.root, path)) as code:
                     self.source[path] = code.read().splitlines()
-        except FileNotFoundError:
+        except FileNotFoundError as error:
             if srcloct.is_builtin(path): # <builtin-library-malloc>, etc.
                 return None
             raise UserWarning(
                 "CodeSnippet lookup: file not found: {}".format(path)
-            )
+            ) from error
 
         # return the whole statement which may be broken over several lines
         snippet = ' '.join(self.source[path][line:line+5])

--- a/cbmc_viewer/propertyt.py
+++ b/cbmc_viewer/propertyt.py
@@ -127,7 +127,7 @@ class PropertyFromJson(Property):
 
     def __init__(self, json_files):
 
-        super(PropertyFromJson, self).__init__(
+        super().__init__(
             [parse.parse_json_file(json_file)[JSON_TAG]["properties"]
              for json_file in json_files]
         )
@@ -139,7 +139,7 @@ class PropertyFromCbmcJson(Property):
 
     def __init__(self, json_files, root):
 
-        super(PropertyFromCbmcJson, self).__init__(
+        super().__init__(
             [load_cbmc_json(json_file, root) for json_file in json_files]
         )
 
@@ -175,7 +175,7 @@ class PropertyFromCbmcXml(Property):
 
     def __init__(self, xml_files, root):
 
-        super(PropertyFromCbmcXml, self).__init__(
+        super().__init__(
             [load_cbmc_xml(xml_file, root) for xml_file in xml_files]
         )
 

--- a/cbmc_viewer/reachablet.py
+++ b/cbmc_viewer/reachablet.py
@@ -98,7 +98,7 @@ class ReachableFromJson(Reachable):
 
     def __init__(self, json_files):
 
-        super(ReachableFromJson, self).__init__(
+        super().__init__(
             [parse.parse_json_file(json_file, fail=True)[JSON_TAG]["reachable"]
              for json_file in json_files]
         )
@@ -111,7 +111,7 @@ class ReachableFromCbmcJson(Reachable):
 
     def __init__(self, json_files, root):
 
-        super(ReachableFromCbmcJson, self).__init__(
+        super().__init__(
             [load_cbmc_json(json_file, root) for json_file in json_files]
         )
 
@@ -159,7 +159,7 @@ class ReachableFromCbmcXml(Reachable):
 
     def __init__(self, xml_files, root):
 
-        super(ReachableFromCbmcXml, self).__init__([])
+        super().__init__([])
 
         _, _ = xml_files, root
         raise UserWarning("The goto-analyzer --xml option generates text "
@@ -176,12 +176,12 @@ class ReachableFromGoto(Reachable):
         try:
             analyzer_output = runt.run(cmd, cwd=cwd)
         except subprocess.CalledProcessError as err:
-            raise UserWarning('Failed to run {}: {}'.format(cmd, str(err)))
+            raise UserWarning('Failed to run {}: {}'.format(cmd, str(err))) from err
 
         json_data = parse.parse_json_string(
             analyzer_output, fail=True, goto_analyzer=True
         )
-        super(ReachableFromGoto, self).__init__(
+        super().__init__(
             [parse_cbmc_json(json_data, root)]
         )
 

--- a/cbmc_viewer/resultt.py
+++ b/cbmc_viewer/resultt.py
@@ -178,7 +178,7 @@ class ResultFromJson(Result):
     """CBMC property checking results from make-result"""
 
     def __init__(self, json_files):
-        super(ResultFromJson, self).__init__(
+        super().__init__(
             [self.load_results(json_file) for json_file in json_files]
         )
 
@@ -203,7 +203,7 @@ class ResultFromCbmcText(Result):
     """CBMC property checking results from CBMC text output"""
 
     def __init__(self, text_files):
-        super(ResultFromCbmcText, self).__init__(
+        super().__init__(
             [self.parse_results(text_file) for text_file in text_files]
         )
 
@@ -283,7 +283,7 @@ class ResultFromCbmcJson(Result):
     """CBMC property checking results from CBMC json output"""
 
     def __init__(self, json_files):
-        super(ResultFromCbmcJson, self).__init__(
+        super().__init__(
             [self.parse_results(json_file) for json_file in json_files]
         )
 
@@ -359,7 +359,7 @@ class ResultFromCbmcXml(Result):
     """CBMC property checking results from CBMC xml output"""
 
     def __init__(self, xml_files):
-        super(ResultFromCbmcXml, self).__init__(
+        super().__init__(
             [self.parse_results(xml_file) for xml_file in xml_files]
         )
 

--- a/cbmc_viewer/sourcet.py
+++ b/cbmc_viewer/sourcet.py
@@ -185,9 +185,7 @@ class SourceFromJson(Source):
             return {'root': roots[0], 'files': files}
 
         source = merge([load(source_json) for source_json in source_jsons])
-        super(SourceFromJson, self).__init__(source['root'],
-                                             source['files'],
-                                             sloc)
+        super().__init__(source['root'], source['files'], sloc)
 
 ################################################################
 
@@ -201,7 +199,7 @@ class SourceFromGoto(Source):
             raise UserWarning('No goto program')
 
         files = sorted(symbol_table.source_files(goto, wkdir))
-        super(SourceFromGoto, self).__init__(srcdir, files, sloc)
+        super().__init__(srcdir, files, sloc)
 
 ################################################################
 
@@ -223,7 +221,7 @@ class SourceFromFind(Source):
         """
 
         files = self.find_sources(root, exclude, extensions)
-        super(SourceFromFind, self).__init__(root, files, sloc)
+        super().__init__(root, files, sloc)
 
     @staticmethod
     def find_sources(root, exclude, extensions):
@@ -251,7 +249,7 @@ class SourceFromWalk(Source):
         """Use walk to list the source files under root."""
 
         files = self.find_sources(root, exclude, extensions)
-        super(SourceFromWalk, self).__init__(root, files, sloc)
+        super().__init__(root, files, sloc)
 
     @staticmethod
     def find_sources(root, exclude=None, extensions=None):
@@ -306,7 +304,7 @@ class SourceFromMake(Source):
         """
 
         files = self.find_sources(build)
-        super(SourceFromMake, self).__init__(root, files, sloc)
+        super().__init__(root, files, sloc)
 
     def find_sources(self, build):
         """Use make to list the source files used to build a goto binary."""

--- a/cbmc_viewer/symbolt.py
+++ b/cbmc_viewer/symbolt.py
@@ -123,7 +123,7 @@ class SymbolFromJson(Symbol):
         def merge(tables):
             return util.merge_dicts(tables)
 
-        super(SymbolFromJson, self).__init__(
+        super().__init__(
             merge([load(symbol_json) for symbol_json in symbol_jsons])
         )
 
@@ -162,7 +162,7 @@ class SymbolFromGoto(Symbol):
         symbols = file_symbols
         symbols.update(table_symbols)
 
-        super(SymbolFromGoto, self).__init__(symbols)
+        super().__init__(symbols)
 
 ################################################################
 
@@ -179,7 +179,7 @@ class SymbolFromCtags(Symbol):
     # options −−list−maps and −−langmap.
 
     def __init__(self, root, files):
-        super(SymbolFromCtags, self).__init__(
+        super().__init__(
             self.build_symbol_table(
                 root, ctags_symbols(run_ctags(root, files))
             )
@@ -195,7 +195,7 @@ class SymbolFromEtags(Symbol):
     """
 
     def __init__(self, root, files):
-        super(SymbolFromEtags, self).__init__(
+        super().__init__(
             self.build_symbol_table(
                 root, etags_symbols(run_etags(root, files))
             )

--- a/cbmc_viewer/tracet.py
+++ b/cbmc_viewer/tracet.py
@@ -166,7 +166,7 @@ class TraceFromJson(Trace):
     """Load error traces from output of make-trace."""
 
     def __init__(self, json_files):
-        super(TraceFromJson, self).__init__(
+        super().__init__(
             [load_traces(json_file) for json_file in json_files]
         )
 
@@ -182,7 +182,7 @@ class TraceFromCbmcText(Trace):
 
     def __init__(self, text_files, root, wkdir):
         root = srcloct.abspath(root)
-        super(TraceFromCbmcText, self).__init__(
+        super().__init__(
             [parse_text_traces(text_file, root, wkdir)
              for text_file in text_files]
         )
@@ -294,7 +294,7 @@ class TraceFromCbmcXml(Trace):
 
     def __init__(self, xml_files, root):
         root = srcloct.abspath(root)
-        super(TraceFromCbmcXml, self).__init__(
+        super().__init__(
             [parse_xml_traces(xml_file, root) for xml_file in xml_files]
         )
 
@@ -456,7 +456,7 @@ class TraceFromCbmcJson(Trace):
 
     def __init__(self, json_files, root):
         root = srcloct.abspath(root)
-        super(TraceFromCbmcJson, self).__init__(
+        super().__init__(
             [parse_json_traces(json_file, root) for json_file in json_files]
         )
 


### PR DESCRIPTION
Pylint clean up.  Mostly the latest version of pylint started suggesting using the Python 3 style of subclassing (call super() without arguments, why did we not do this from the start) and suggesting the use of "raise from".