### PR TITLE
Updated coverage parsing to allow functions with colons in name.

### DIFF
--- a/cbmc_viewer/coveraget.py
+++ b/cbmc_viewer/coveraget.py
@@ -495,7 +495,11 @@ def parse_chunk(chunk):
     """Parse a chunk of coverage"""
 
     # The chunk has the form FILE:FUNCTION:LINES
-    filename, function, lines = chunk.split(':')
+    # Don't use split in order to allow FUNCTION to contain ':'
+    first_colon, last_colon = chunk.find(':'), chunk.rfind(':')
+    filename = chunk[:first_colon]
+    function = chunk[first_colon + 1:last_colon]
+    lines = chunk[last_colon + 1:]
     return [(filename, function, line) for line in parse_lines(lines)]
 
 def parse_lines(lines):


### PR DESCRIPTION
*Resolved issues:*
Issue #39 

*Description of changes:*
Instead of splitting `FILE:FUNCTION:LINES` chunk on all colons, splits it only on the first and last colon, allowing the `FUNCTION` to contain colons safely. File names and line numbers can't contain colons, so this should be more robust.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
