### PR TITLE
Source language flag

### DIFF
--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -10,6 +10,7 @@ import platform
 from cbmc_viewer import filet
 from cbmc_viewer import symbolt
 from cbmc_viewer import version as viewer_version
+from cbmc_viewer.source_language import Language
 from cbmc_viewer.sourcet import Sources
 from cbmc_viewer.symbolt import Tags
 
@@ -320,8 +321,8 @@ def source_language(parser):
 
     parser.add_argument(
         '--source-language',
-        default='C',
-        choices=['C', 'rust'],
+        default=Language.C,
+        choices=Language.ALL_LANGUAGE_NAMES,
         help='Set the source language of the analyzed file.'
     )
     return parser
@@ -523,6 +524,11 @@ def warn_against_using_text_for_cbmc_output(args):
             logging.warning("Use xml or json instead of text for "
                             "better results: %s", filenames)
 
+def set_default_language(args):
+    'Set the default source language for language specific features.'
+    
+    Language.set_default_language(args.source_language)
+
 def defaults(args):
     'Set default values based on command line arguments.'
 
@@ -531,6 +537,7 @@ def defaults(args):
     args = default_source_method(args)
     args = default_tags_method(args)
     warn_against_using_text_for_cbmc_output(args)
+    set_default_language(args)
 
     if hasattr(args, 'srcdir'):
         args.srcdir = os.path.abspath(args.srcdir)

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -315,6 +315,17 @@ def version(parser):
     )
     return parser
 
+def source_language(parser):
+    'Define --source-language command line option.'
+
+    parser.add_argument(
+        '--source-language',
+        default='C',
+        choices=['C', 'rust'],
+        help='Set the source language of the analyzed file.'
+    )
+    return parser
+
 ################################################################
 # Depricated command line options
 #

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -323,7 +323,7 @@ def source_language(parser):
         '--source-language',
         default=Language.C,
         choices=Language.ALL_LANGUAGE_NAMES,
-        help='Set the source language of the analyzed file.'
+        help='The source language compiled to produce the goto binary.'
     )
     return parser
 
@@ -524,11 +524,6 @@ def warn_against_using_text_for_cbmc_output(args):
             logging.warning("Use xml or json instead of text for "
                             "better results: %s", filenames)
 
-def set_default_language(args):
-    'Set the default source language for language specific features.'
-    
-    Language.set_default_language(args.source_language)
-
 def defaults(args):
     'Set default values based on command line arguments.'
 
@@ -537,7 +532,7 @@ def defaults(args):
     args = default_source_method(args)
     args = default_tags_method(args)
     warn_against_using_text_for_cbmc_output(args)
-    set_default_language(args)
+    Language.default_language(args.source_language)
 
     if hasattr(args, 'srcdir'):
         args.srcdir = os.path.abspath(args.srcdir)

--- a/cbmc_viewer/source_language.py
+++ b/cbmc_viewer/source_language.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source file language for language dependent features."""
+
+class Language:
+    C = "C"
+    RUST = "rust"
+    ALL_LANGUAGE_NAMES = [C, RUST]
+
+    _default_language = None
+    
+    @classmethod
+    def get_default_language(cls):
+        return cls._default_language
+
+    @classmethod
+    def get_default_language_or_fail(cls):
+        if cls._default_language == None:
+            raise Exception("Default language is not set.")
+        
+        return cls._default_language
+    
+    @classmethod
+    def set_default_language(cls, lang):
+        assert lang in cls.ALL_LANGUAGE_NAMES, f"Invalid language: {lang}"
+        
+        cls._default_language = cls.get_language(lang)
+
+    @staticmethod
+    def get_language(name):
+        name_map = {
+            Language.C: C,
+            Language.RUST: Rust
+        }
+        return name_map[name]
+
+    @staticmethod
+    def get_language_name(lang):
+        return lang.get_name()
+
+    @classmethod
+    def get_name(cls):
+        return cls.get_default_language_or_fail().get_name()
+
+    @classmethod
+    def get_pretty_name_regex(cls):
+        return cls.get_default_language_or_fail().get_pretty_name_regex()
+
+    @classmethod
+    def get_symbol_regex(cls):
+        return cls.get_default_language_or_fail().get_symbol_regex()
+
+Language.default_language = Language
+
+class Rust(Language):
+    @staticmethod
+    def get_name():
+        return Language.RUST
+
+    @staticmethod
+    def get_pretty_name_regex():
+        return '^([a-zA-Z0-9_<>: ]+)$', 1
+
+    @staticmethod
+    def get_symbol_regex():
+        return '^([a-zA-Z0-9_]+)$', 1
+
+class C(Language):
+    @staticmethod
+    def get_name():
+        return Language.C
+
+    @staticmethod
+    def get_pretty_name_regex():
+        return '.*[^\S]([a-zA-Z0-9_]+)$', 1
+
+    @staticmethod
+    def get_symbol_regex():
+        return '^(tag-)?([a-zA-Z0-9_]+)$', 2

--- a/cbmc_viewer/source_language.py
+++ b/cbmc_viewer/source_language.py
@@ -4,9 +4,25 @@
 """Source file language for language dependent features."""
 
 class Language:
+    """A utility class to handle language-specific functionality.
+
+    The class acts as the main API for language-specific functionality.
+    It:
+    - Provides language constants and utility functions
+    - Acts as a super-class to all specfic language classes
+    - Provides language-specific utility functions and automatically
+      redirects to the correct language utility class
+    """
+
+    ######################################
+    # Constants
+
     C = "C"
     RUST = "rust"
     ALL_LANGUAGE_NAMES = [C, RUST]
+
+    ######################################
+    # Default language handlers
 
     _default_language = None
     
@@ -27,8 +43,12 @@ class Language:
         
         cls._default_language = cls.get_language(lang)
 
+    ######################################
+    # Utility functions
+
     @staticmethod
     def get_language(name):
+        'Gets the language utility class from a string name.'
         name_map = {
             Language.C: C,
             Language.RUST: Rust
@@ -37,36 +57,35 @@ class Language:
 
     @staticmethod
     def get_language_name(lang):
+        'Gets the string name of a language from the utility class.'
         return lang.get_name()
+
+    ######################################
+    # Language specific utility functions
+    # These should be over-ridden by 
+    # specific language implementations
 
     @classmethod
     def get_name(cls):
+        """The name of the language"""
         return cls.get_default_language_or_fail().get_name()
 
     @classmethod
     def get_pretty_name_regex(cls):
+        """A regex pattern to match pretty names,
+        and which group in the pattern should be used"""
         return cls.get_default_language_or_fail().get_pretty_name_regex()
 
     @classmethod
     def get_symbol_regex(cls):
+        """A regex pattern to match symbol names,
+        and which group in the pattern should be used"""
         return cls.get_default_language_or_fail().get_symbol_regex()
 
-Language.default_language = Language
-
-class Rust(Language):
-    @staticmethod
-    def get_name():
-        return Language.RUST
-
-    @staticmethod
-    def get_pretty_name_regex():
-        return '^([a-zA-Z0-9_<>: ]+)$', 1
-
-    @staticmethod
-    def get_symbol_regex():
-        return '^([a-zA-Z0-9_]+)$', 1
 
 class C(Language):
+    """C-specific utility functions."""
+
     @staticmethod
     def get_name():
         return Language.C
@@ -78,3 +97,18 @@ class C(Language):
     @staticmethod
     def get_symbol_regex():
         return '^(tag-)?([a-zA-Z0-9_]+)$', 2
+
+class Rust(Language):
+    """Rust-specific utility functions."""
+
+    @staticmethod
+    def get_name():
+        return Language.RUST
+
+    @staticmethod
+    def get_pretty_name_regex():
+        return '^([a-zA-Z0-9_<>: ]+)$', 1
+
+    @staticmethod
+    def get_symbol_regex():
+        return '^([a-zA-Z0-9_]+)$', 1

--- a/cbmc_viewer/symbol_table.py
+++ b/cbmc_viewer/symbol_table.py
@@ -62,20 +62,8 @@ def parse_symbol(sym):
     # Symbol......: tag-struct_name
     # Symbol......: tag-union_name
 
-    # Match the shape of the input format
-    line_match = re.match("^Symbol\.\.\.\.\.\.: (.*)$", sym)
-    if not line_match:
-        logging.warning("Invalid symbol line form")
-        logging.warning("  {}".format(sym))
-        return None
-    name = line_match.group(1)
-
-    # Match the allowed symbol names
-    name_regex, name_group = Language.get_symbol_regex()
-    name_match = re.match(name_regex, name)
-    if name_match:
-        return name_match.group(name_group)
-    return None
+    name = sym.split(":", 1)[1].strip()
+    return Language.match_symbol(name)
 
 def parse_location(loc, wkdir):
     """Symbol source location from location line."""
@@ -111,20 +99,8 @@ def parse_pretty_name(sym):
     # Pretty name.: struct struct_name
     # Pretty name.: union union_name
 
-    # Match the shape of the input format
-    line_match = re.match("^Pretty name\.: (.*)$", sym)
-    if not line_match:
-        logging.warning("Invalid pretty name line form")
-        logging.warning("  {}".format(sym))
-        return None
-    name = line_match.group(1)
-
-    # Match the allowed pretty names
-    name_regex, name_group = Language.get_pretty_name_regex()
-    name_match = re.match(name_regex, name)
-    if name_match:
-        return name_match.group(name_group)
-    return None
+    name = sym.split(":", 1)[1].strip()
+    return Language.match_pretty_name(name)
 
 def parse_symbol_table(definitions, wkdir):
     """Extract symbols and source locations from symbol table definitions."""

--- a/cbmc_viewer/symbol_table.py
+++ b/cbmc_viewer/symbol_table.py
@@ -9,6 +9,7 @@ import re
 
 from cbmc_viewer import runt
 from cbmc_viewer import srcloct
+from cbmc_viewer.source_language import Language
 
 def symbol_table(goto):
     """Extract symbol table from goto binary as lines of text."""
@@ -61,10 +62,17 @@ def parse_symbol(sym):
     # Symbol......: tag-struct_name
     # Symbol......: tag-union_name
 
-    name = sym.strip().split()[-1]
-    match = re.match('^(tag-)?([a-zA-Z0-9_]+)$', name)
-    if match:
-        return match.group(2)
+    line_match = re.match("^Symbol\.\.\.\.\.\.: (.*)$", sym)
+    if not line_match:
+        logging.warning("Invalid symbol line form")
+        logging.warning("  {}".format(sym))
+        return None
+    name = line_match.group(1)
+
+    name_regex, name_group = Language.get_symbol_regex()
+    name_match = re.match(name_regex, name)
+    if name_match:
+        return name_match.group(name_group)
     return None
 
 def parse_location(loc, wkdir):
@@ -101,9 +109,17 @@ def parse_pretty_name(sym):
     # Pretty name.: struct struct_name
     # Pretty name.: union union_name
 
-    name = sym.strip().split()[-1]
-    if re.match('^[a-zA-Z0-9_]+$', name):
-        return name
+    line_match = re.match("^Pretty name\.: (.*)$", sym)
+    if not line_match:
+        logging.warning("Invalid pretty name line form")
+        logging.warning("  {}".format(sym))
+        return None
+    name = line_match.group(1)
+
+    name_regex, name_group = Language.get_pretty_name_regex()
+    name_match = re.match(name_regex, name)
+    if name_match:
+        return name_match.group(name_group)
     return None
 
 def parse_symbol_table(definitions, wkdir):

--- a/cbmc_viewer/symbol_table.py
+++ b/cbmc_viewer/symbol_table.py
@@ -62,6 +62,7 @@ def parse_symbol(sym):
     # Symbol......: tag-struct_name
     # Symbol......: tag-union_name
 
+    # Match the shape of the input format
     line_match = re.match("^Symbol\.\.\.\.\.\.: (.*)$", sym)
     if not line_match:
         logging.warning("Invalid symbol line form")
@@ -69,6 +70,7 @@ def parse_symbol(sym):
         return None
     name = line_match.group(1)
 
+    # Match the allowed symbol names
     name_regex, name_group = Language.get_symbol_regex()
     name_match = re.match(name_regex, name)
     if name_match:
@@ -109,6 +111,7 @@ def parse_pretty_name(sym):
     # Pretty name.: struct struct_name
     # Pretty name.: union union_name
 
+    # Match the shape of the input format
     line_match = re.match("^Pretty name\.: (.*)$", sym)
     if not line_match:
         logging.warning("Invalid pretty name line form")
@@ -116,6 +119,7 @@ def parse_pretty_name(sym):
         return None
     name = line_match.group(1)
 
+    # Match the allowed pretty names
     name_regex, name_group = Language.get_pretty_name_regex()
     name_match = re.match(name_regex, name)
     if name_match:

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -76,6 +76,7 @@ def create_parser():
     optionst.log(other)
     optionst.config(other)
     optionst.version(other)
+    optionst.source_language(other)
 
     depricated = parser.add_argument_group(
         'Depricated',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR introduces the ability to specify a source file language in order to have language-specific functionality. The language is set with a flag, and defaults to C to allow currently existing uses of cbmc-viewer to continue functioning the same as before.

This PR additionally introduces language-specific regex patterns for pretty names in order to fix some issues with trace visualizations in Rust.

The two changes are coupled together in a single PR in order to discuss the design of the new `Language` class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
