### PR TITLE
Fix destination path to be relative to current directory.

### DIFF
--- a/cbmc_viewer/markup_link.py
+++ b/cbmc_viewer/markup_link.py
@@ -48,7 +48,7 @@ def link_text_to_file(text, to_file, from_file=None):
         return html.escape(str(text))
 
     from_file = from_file or '.'
-    path = path_to_file(to_file, from_file)
+    path = path_to_file(os.path.relpath(to_file), os.path.relpath(from_file))
     return '<a href="{}.html">{}</a>'.format(path, text)
 
 def link_text_to_line(text, to_file, line, from_file=None):
@@ -59,7 +59,7 @@ def link_text_to_line(text, to_file, line, from_file=None):
 
     from_file = from_file or '.'
     line = int(line)
-    path = path_to_file(to_file, from_file)
+    path = path_to_file(os.path.relpath(to_file), os.path.relpath(from_file))
     return '<a href="{}.html#{}">{}</a>'.format(path, line, text)
 
 def link_text_to_srcloc(text, srcloc, from_file=None):


### PR DESCRIPTION
*Issue #, if available:*

Fixes issue #45 

*Description of changes:*

Converts to/from files to relative paths before passing them into `path_to_file`, which expects two paths relative to the same root. 

I don't believe this should cause issues with existing CBMC-viewer usage:
- If both paths are already relative (even if not relative to current directory) , then `os.path.relpath` won't change either of them, so there is no issue.
- If both paths are absolute, then they still have the same relative difference, and so `path_to_file` should return the same value.
- If one of the paths is absolute and the other is relative to the current directory, then `os.path.relpath` will not change the relative difference between the two paths.
- If one of the paths is absolute and the other is relative to a directory *other than the current directory*, then this change will lead to invalid links, however this scenario would already lead to invalid links prior to this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
