### PR TITLE
Don't link error traces to library source files

### DIFF
--- a/cbmc_viewer/markup_link.py
+++ b/cbmc_viewer/markup_link.py
@@ -44,8 +44,7 @@ def path_to_file(dst, src):
 def link_text_to_file(text, to_file, from_file=None):
     """Link text to a file in the source tree."""
 
-    # create links only to files under srcdir (with paths relative to srcdir)
-    if srcloct.is_builtin(to_file) or srcloct.is_missing(to_file) or os.path.isabs(to_file):
+    if srcloct.file_is_not_a_source_file(to_file):
         return html.escape(str(text))
 
     from_file = from_file or '.'
@@ -55,8 +54,7 @@ def link_text_to_file(text, to_file, from_file=None):
 def link_text_to_line(text, to_file, line, from_file=None):
     """Link text to a line in a file in the source tree."""
 
-    # create links only to files under srcdir (with paths relative to srcdir)
-    if srcloct.is_builtin(to_file) or srcloct.is_missing(to_file) or os.path.isabs(to_file):
+    if srcloct.file_is_not_a_source_file(to_file):
         return html.escape(str(text))
 
     from_file = from_file or '.'

--- a/cbmc_viewer/markup_link.py
+++ b/cbmc_viewer/markup_link.py
@@ -44,7 +44,8 @@ def path_to_file(dst, src):
 def link_text_to_file(text, to_file, from_file=None):
     """Link text to a file in the source tree."""
 
-    if srcloct.is_builtin(to_file) or srcloct.is_missing(to_file):
+    # create links only to files under srcdir (with paths relative to srcdir)
+    if srcloct.is_builtin(to_file) or srcloct.is_missing(to_file) or os.path.isabs(to_file):
         return html.escape(str(text))
 
     from_file = from_file or '.'
@@ -54,7 +55,8 @@ def link_text_to_file(text, to_file, from_file=None):
 def link_text_to_line(text, to_file, line, from_file=None):
     """Link text to a line in a file in the source tree."""
 
-    if srcloct.is_builtin(to_file) or srcloct.is_missing(to_file):
+    # create links only to files under srcdir (with paths relative to srcdir)
+    if srcloct.is_builtin(to_file) or srcloct.is_missing(to_file) or os.path.isabs(to_file):
         return html.escape(str(text))
 
     from_file = from_file or '.'

--- a/cbmc_viewer/srcloct.py
+++ b/cbmc_viewer/srcloct.py
@@ -118,6 +118,20 @@ def is_missing(name):
     return name == MISSING
 
 ################################################################
+
+def file_is_not_a_source_file(name):
+    """The file name cannot refer to a source file.
+
+    The source location for a source file under the source root will
+    refer to the source file with a relative pathname that is relative
+    to the source root.  It will not be an absolute pathname (eg, to a
+    file in a system library), it will not refer to a built-in
+    function, and it will not be missing.
+    """
+
+    return os.path.isabs(name) or is_builtin(name) or is_missing(name)
+
+################################################################
 # Construct a viewer source location from cbmc source locations
 # appearing in cbmc output.
 


### PR DESCRIPTION
*Issue #45, if available:* 

Issue https://github.com/awslabs/aws-viewer-for-cbmc/issues/45

*Description of changes:*

Viewer annotates only source files under SRCDIR, links steps of an
error trace only to lines of code in files under SRCDIR, and uses path
names relative to SRCDIR for files under SRCDIR.  With RMC, we see for
the first time errors triggered by lines of code in the RMC
implementation (eg, the Rust standard library) not under SRCDIR, and
viewer fails when it tries to generate a link to the line of code
triggering the error (in a library source file given by an absolute
path name).

With this commit, viewer will no longer try to link to a file specified
with an absolute path name (to a file not under SRCDIR).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
