### PR TITLE
Add proof summary scripts (work in progress)

### DIFF
--- a/summary/Makefile
+++ b/summary/Makefile
@@ -1,0 +1,11 @@
+default:
+	@echo Nothing to do
+
+pylint:
+	pylint \
+		--disable missing-function-docstring \
+		--disable missing-module-docstring \
+		--disable duplicate-code \
+		--module-rgx '[\w-]+' \
+		--max-line-length 80 \
+	*.py

--- a/summary/Makefile
+++ b/summary/Makefile
@@ -1,5 +1,5 @@
 default:
-	@echo Nothing to do
+	@echo Nothing to do for $@
 
 pylint:
 	pylint \

--- a/summary/README.md
+++ b/summary/README.md
@@ -4,7 +4,7 @@ being used in the proofs.  This is a work-in-progress.
 
 * projects.json is a list of projects on gitub.  Each entry gives the
   url for the github repository and the path within the repository to
-  the cbmc proofs.
+  the cbmc proofs.  See more below.
 
 * summary.py scans the list of projects and clones the repositories,
   runs the proofs, summarizes the results, and produces a table of the
@@ -12,3 +12,33 @@ being used in the proofs.  This is a work-in-progress.
 
 * stubs.py summarizes the stubs and undefined functions used in a proof.
   It is used as a library by summary.py, but see `stubs.py --help`.
+
+Here is an example of a project list:
+
+```
+projects.json:
+    {
+      "Baseball": {
+        "github": "https://github.com/johnqpublic/baseball-fantasy-team.git",
+        "proofs": "tools/cbmc/proofs"
+      },
+      "Football": {
+        "github": "https://github.com/johnqpublic/football-fantasy-team.git",
+        "proofs": "test/cbmc/proofs"
+      }
+    }
+```
+
+This list describes two projects named "Baseball" and "Football".  For
+"Baseball",
+
+* `https://github.com/johnqpublic/baseball-fantasy-team.git` is the
+  URL for the code repository, and
+* `tools/cbmc/proofs` is the path within the repository to the
+  directory under which all of the CBMC proofs can be found.
+
+Similarly for "Football". The names "Baseball" and "Football" are just
+short names for the projects.  They are used to refer the the projects
+on the command line with `summary.py --project Baseball Football` and
+they are used as column headers for the projects in the spreadsheet
+produced by `summary.py --chart`.

--- a/summary/README.md
+++ b/summary/README.md
@@ -1,0 +1,14 @@
+This directory contains a script that scans the viewer output for a
+set of and produce a summary of the stubs and undefined functions
+being used in the proofs.  This is a work-in-progress.
+
+* projects.json is a list of projects on gitub.  Each entry gives the
+  url for the github repository and the path within the repository to
+  the cbmc proofs.
+
+* summary.py scans the list of projects and clones the repositories,
+  runs the proofs, summarizes the results, and produces a table of the
+  results.  See `summary.py --help`.
+
+* stubs.py summarizes the stubs and undefined functions used in a proof.
+  It is used as a library by summary.py, but see `stubs.py --help`.

--- a/summary/projects.json
+++ b/summary/projects.json
@@ -1,0 +1,58 @@
+{
+  "Amn FreeRTOS": {
+    "github": "git@github.com:aws/amazon-freertos",
+    "proofs": "tools/cbmc/proofs"
+  },
+  "Defender": {
+    "github": "git@github.com:aws/device-defender-for-aws-iot-embedded-sdk",
+    "proofs": "test/cbmc/proofs"
+  },
+  "Shadow": {
+    "github": "git@github.com:aws/device-shadow-for-aws-iot-embedded-sdk",
+    "proofs": "test/cbmc/proofs"
+  },
+  "Jobs": {
+    "github": "git@github.com:aws/jobs-for-aws-iot-embedded-sdk",
+    "proofs": "test/cbmc/proofs"
+  },
+  "OTA": {
+    "github": "git@github.com:aws/ota-for-aws-iot-embedded-sdk",
+    "proofs": "test/cbmc/proofs"
+  },
+  "SigV4": {
+    "github": "git@github.com:aws/SigV4-for-AWS-IoT-embedded-sdk",
+    "proofs": "test/cbmc/proofs"
+  },
+  "FreeRTOS": {
+    "github": "git@github.com:FreeRTOS/FreeRTOS",
+    "proofs": "FreeRTOS/Test/CBMC/proofs"
+  },
+  "FreeRTOS TCP": {
+    "github": "git@github.com:FreeRTOS/FreeRTOS-Plus-TCP",
+    "proofs": "test/cbmc/proofs"
+  },
+  "HTTP": {
+    "github": "git@github.com:FreeRTOS/coreHTTP",
+    "proofs": "test/cbmc/proofs"
+  },
+  "JSON": {
+    "github": "git@github.com:FreeRTOS/coreJSON",
+    "proofs": "test/cbmc/proofs"
+  },
+  "MQTT": {
+    "github": "git@github.com:FreeRTOS/coreMQTT",
+    "proofs": "test/cbmc/proofs"
+  },
+  "MQTT-Agent": {
+    "github": "git@github.com:FreeRTOS/coreMQTT-Agent",
+    "proofs": "test/cbmc/proofs"
+  },
+  "PKCS11": {
+    "github": "git@github.com:FreeRTOS/corePKCS11",
+    "proofs": "test/cbmc/proofs"
+  },
+  "SNTP": {
+    "github": "git@github.com:FreeRTOS/coreSNTP",
+    "proofs": "test/cbmc/proofs"
+  }
+}

--- a/summary/stubs.py
+++ b/summary/stubs.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+
+"""List stubbed functions and missing functions in a set of CBMC proofs.
+
+    This script scans the json files produced by cbmc-viewer for a set
+    of proofs and constructs for each proof three lists:
+
+    * stubbed: the list of stubbed functions used in the proof (those
+      functions defined in code outside the project code itself and under
+      the cbmc directory in most proof projects),
+
+    * removed: the list of undefined functions removed by the proof author
+      (and listed as as "expected-missing-functions" in the cbmc-viewer
+      configuration file cbmc-viewer.json), and
+
+    * missing: the list of undefined functions that are simply missing
+      from the proof.
+
+    All of the needed data is in the files viewer-result.json (listing the
+    undefined functions in the proof), viewer-reachable.json (list the
+    reachable functions in the proof), and cbmc-viewer.json (listing the
+    known undefined functions).  The script requires some location
+    information (eg, the paths to the json files) that can be provided
+    with command line flags, but the script tries to guess this location
+    information when it is omitted from the command line.  You can view
+    the guesses made with --verbose if the script seems to have guessed
+    wrong.
+
+    NOTE: All of this information we need is in the goto binary
+    itself, but 'goto-analyzer --reachable-functions' does not include
+    undefined functions in the list of reachable functions.
+"""
+
+
+import re
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+
+################################################################
+# Command line parser
+
+def create_parser():
+    desc = "Summarize the stubs and undefined functions used in a proof."
+    args = [
+        {
+            "flag": "--proof",
+            "nargs": "*",
+            "help": """
+            A list of proof names. A proof name is interpreted as a
+            relative path from PROOFDIR to a directory containing a proof
+            (see --proofdir PROOFDIR).
+            By default, if PROOF is not specified, use all proofs
+            discovered under PROOFDIR. """
+        },
+        {
+            "flag": "--srcdir",
+            "help": """
+            The root of the source tree.   SRCDIR is used only to
+            guess CBMCPATH if it is not specified (see
+            --cbmcpath CBMCPATH.) By default, if SRCDIR is not specified,
+            look for the Makefile in a proof directory and use the
+            argument to --srcdir used in the invocation of cbmc-viewer
+            by that Makefile.
+            """
+        },
+        {
+            "flag": "--proofdir",
+            "default": '.',
+            "help": """
+            The root of the proof tree.  PROOFDIR is used only to
+            compute the full path to a proof directory. A proof name
+            is interpreted as a relative path from PROOFDIR to a
+            directory containing a proof, so PROOFDIR can by any
+            directory containing a proof. By default,
+            PROOFDIR is the current directory. (Default: %(default)s)
+            """
+        },
+        {
+            "flag": "--cbmcpath",
+            "help": """
+            The relative path from the source root SRCDIR to the cbmc
+            root CBMCDIR (see --srcdir SRCDIR), typically 'test/cbmc'.
+            CBMCDIR contains all code written
+            specifically to build the proofs and typically also includes
+            the proofs themselves.  All code under CBMCDIR
+            is considered to be a proof stub.  By default, if CBMCPATH
+            is not specified, then CBMCDIR is the parent of PROOFDIR
+            (see --proofdir PROOFDIR), and CBMCPATH is the relative
+            path from SRCDIR to CBMCDIR (see --srcdir SRCDIR). """
+        },
+        {
+            "flag": "--jsonpath",
+            "help": """
+            The relative path from the proof directory to the json
+            directory containing cbmc-viewer output, typically
+            'report/json' where 'report' is the string specified by
+            the --reportdir or --htmldir flag to cbmc-viewer.  By
+            default, if JSONPATH is not specified, use the path from a
+            proof directory to a directory containing the file
+            'viewer-result.json'. """
+        },
+        {
+            "flag": "--stubbed-usage",
+            "action": "store_true",
+            "help": """
+            Summarize stubbed function usage by "name" mapping each
+            function to the proofs using the stub and by "count"
+            giving a histogram mapping each function to the number of
+            times it is used. """
+        },
+        {
+            "flag": "--removed-usage",
+            "action": "store_true",
+            "help": """
+            Summarize removed function usage by "name" mapping each
+            function to the proofs using the stub and by "count"
+            giving a histogram mapping each function to the number of
+            times it is used. """
+        },
+        {
+            "flag": "--missing-usage",
+            "action": "store_true",
+            "help": """
+            Summarize missing function usage by "name" mapping each
+            function to the proofs using the stub and by "count"
+            giving a histogram mapping each function to the number of
+            times it is used. """
+        },
+        {
+            "flag": "--config",
+            "default": "cbmc-viewer.json",
+            "help": """
+            Name of the cbmc-viewer configuration file.
+            (Default: %(default)s)
+            """
+        },
+        {
+            "flag": "--viewer-reachable",
+            "default": "viewer-reachable.json",
+            "help": """
+            Name of the cbmc-viewer summary of reachable functions.
+            (Default: %(default)s) """
+        },
+        {
+            "flag": "--viewer-result",
+            "default": "viewer-result.json",
+            "help": """
+            Name of the cbmc-viewer summary of results.
+            (Default: %(default)s) """
+        },
+        {
+            "flag": "--verbose",
+            "action": "store_true",
+            "help": "Verbose output"
+        },
+        {
+            "flag": "--debug",
+            "action": "store_true",
+            "help": "Debug output"
+        }
+    ]
+    epilog = """
+    The simplest way to use the script is to run '%(prog)s' in the directory
+    that is the root of the proof tree (usually called 'proofs').
+    """
+
+    parser = argparse.ArgumentParser(description=desc, epilog=epilog)
+    for arg in args:
+        flag = arg['flag']
+        del arg['flag']
+        parser.add_argument(flag, **arg)
+    return parser
+
+def parse_arguments(args=None):
+    return create_parser().parse_args(args=args)
+
+def configure_logger(verbose=False, debug=False):
+    # Logging is configured by the first invocation of logging.basicConfig
+    fmt = '%(levelname)s: %(message)s'
+    if debug:
+        logging.basicConfig(level=logging.DEBUG, format=fmt)
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format=fmt)
+    logging.basicConfig(format=fmt)
+
+################################################################
+# Shell out commands
+
+def run(cmd, cwd=None, encoding=None):
+    """Run a command in a subshell and return the standard output.
+
+    Run the command cmd in the directory cwd and use encoding to
+    decode the standard output.
+    """
+
+    kwds = {
+        'cwd': cwd,
+        'stdout': subprocess.PIPE,
+        'stderr': subprocess.PIPE,
+        'text': True,
+    }
+    if sys.version_info >= (3, 6): # encoding introduced in Python 3.6
+        kwds['encoding'] = encoding
+
+    logging.debug('Running "%s" in %s', ' '.join(cmd), cwd)
+
+    result = subprocess.run(cmd, **kwds, check=False)
+    if result.returncode:
+        logging.debug('Failed command: %s', ' '.join(cmd))
+        logging.debug('Failed return code: %s', result.returncode)
+        logging.debug('Failed stdout: %s', result.stdout.strip())
+        logging.debug('Failed stderr: %s', result.stderr.strip())
+        return []
+
+    # Remove line continuations before splitting stdout into lines
+    # Running command with text=True converts line endings to \n in stdout
+    lines = result.stdout.replace('\\\n', ' ').splitlines()
+    return [strip_whitespace(line) for line in lines]
+
+def strip_whitespace(string):
+    return re.sub(r'\s+', ' ', string).strip()
+
+################################################################
+# Load viewer JSON data
+
+def load_json(name="", path=None):
+    res = {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            res = json.load(handle)
+    except TypeError:
+        logging.debug("%s file name %s is not a string", name, path)
+    except FileNotFoundError:
+        logging.debug("Can't open %s file %s", name, path)
+    except json.decoder.JSONDecodeError:
+        logging.debug("Can't parse %s file %s as json", name, path)
+    return res
+
+def load_config(path=None):
+    path = path or 'cbmc-viewer.json'
+    return load_json("config", path)
+
+def load_viewer_result(path=None):
+    path = path or 'report/json/viewer-result.json'
+    return load_json("viewer result", path)
+
+def load_viewer_reachable(path=None):
+    path = path or 'report/json/viewer-reachable.json'
+    return load_json("viewer reachable", path)
+
+################################################################
+# Parse viewer JSON data
+
+def load_reachable_functions(path=None):
+    reachable = load_viewer_reachable(path)
+    return reachable.get('viewer-reachable', {}).get('reachable', [])
+
+def load_missing_functions(path=None):
+
+    def missing(warning):
+        if warning.strip().startswith('**** WARNING: no body for function'):
+            return warning.strip().split()[-1]
+        return None
+
+    result = load_viewer_result(path)
+    warnings = result.get('viewer-result', {}).get('warning', [])
+    return [fcn for fcn in [missing(warning) for warning in warnings] if fcn]
+
+def load_expected_missing_functions(path=None):
+    config = load_config(path)
+    return config.get('expected-missing-functions', [])
+
+################################################################
+# Summarize proof abstraction
+
+def is_builtin(path):
+    if not path:
+        logging.info("Can't test for builtin: path %s is empty", path)
+        return False
+
+    path = os.path.normpath(path)
+    name = os.path.split(path)[-1]
+    return name.startswith('<built-in') or name.startswith('<builtin-')
+
+def is_cbmc_file(path, cbmcpath):
+    if not path or not cbmcpath:
+        logging.info("Can't test for cbmc stub: "
+                     "path %s or cbmcpath %s is empty", path, cbmcpath)
+        return True # Assume everything is a stub
+
+    path = os.path.normpath(path)
+    cbmcpath = os.path.normpath(cbmcpath)
+    return cbmcpath == os.path.commonpath([path, cbmcpath])
+
+def is_cbmc_harness(path, harness_suffix="harness"):
+    if not path:
+        logging.info("Can't test for cbmc harness: path %s is empty", path)
+        return False
+
+    path = os.path.normpath(path)
+    basename = os.path.basename(path)
+    name = os.path.splitext(basename)[0]
+    return name.endswith(harness_suffix)
+
+def stubbed_reachable_functions(reachable, cbmcpath):
+    reachable = {
+        path: functions for path, functions in reachable.items()
+        if is_cbmc_file(path, cbmcpath)
+        and not is_builtin(path)
+        and not is_cbmc_harness(path)
+    }
+    return { path: sorted(set(reachable[path]))
+             for path in sorted(reachable) if reachable[path]}
+
+def expected_missing_functions(missing, expected):
+    return sorted([fcn for fcn in missing if fcn in expected])
+
+def unexpected_missing_functions(missing, expected):
+    return sorted([fcn for fcn in missing if fcn not in expected])
+
+################################################################
+
+def scan_proof(proof, args):
+    reachable = load_reachable_functions(
+        os.path.join(args.proofdir, proof, args.jsonpath, args.viewer_reachable)
+    )
+    missing = load_missing_functions(
+        os.path.join(args.proofdir, proof, args.jsonpath, args.viewer_result)
+    )
+    expected = load_expected_missing_functions(
+        os.path.join(args.proofdir, proof, args.config)
+    )
+
+    return {
+        'stubbed': stubbed_reachable_functions(reachable, args.cbmcpath),
+        'removed': expected_missing_functions(missing, expected),
+        'missing': unexpected_missing_functions(missing, expected),
+    }
+
+def scan_proofs(proofs, args):
+
+    # Don't bother to map proofs to scans in the special case that the
+    # only proof directory is the current directory.
+    if proofs == ['.']:
+        return scan_proof('.', args)
+
+    return { proof: scan_proof(proof, args) for proof in sorted(proofs)}
+
+################################################################
+# Extract a cbmc-viewer command from make or litani
+
+def command_name(command):
+    """Extract command name from command line.
+
+    Assume that the first word in the command is the path to the
+    binary (and not, for example, an environment variable definition).
+    """
+
+    return os.path.basename(command.strip().split()[0])
+
+def is_viewer_command(command, viewer_names=None):
+    """Is the command an invocation of cbmc-viewer?
+
+    Assume that the first word in the command is the path to the
+    binary (and not, for example, an environment variable definition).
+    Assume that the valid names for the cbmc-viewer (the file name)
+    are in viewer_names.
+    """
+
+    viewer_names = viewer_names or ['cbmc-viewer']
+
+    if not command: # eg, blank line
+        return False
+    return command_name(command) in viewer_names
+
+def is_litani_command(command, litani_names=None):
+    """Is the command an invocation of litani?
+
+    Assume that the first word in the command is the path to the
+    binary (and not, for example, an environment variable definition).
+    Assume that the valid names for the litani binary (the file name)
+    are in litani_names.
+    """
+
+    litani_names = litani_names or ['litani']
+
+    if not command: # eg, blank line
+        return False
+    return command_name(command) in litani_names
+
+def extract_command_from_litani_command(command):
+    """Extract the shell command from a litani command."""
+
+    command = command.strip()
+    match1 = re.search(' --command +"([^"]*)"', command)
+    match2 = re.search(" --command +'([^']*)'", command)
+    match3 = re.search(' --command +([^ ]*)', command)
+    cmd1 = match1.group(1).strip() if match1 else None
+    cmd2 = match2.group(1).strip() if match2 else None
+    cmd3 = match3.group(1).strip() if match3 else None
+
+    cmd = cmd1 or cmd2 or cmd3
+    return cmd if cmd else command
+
+def get_make_commands(proof=None):
+    """Get the list of commands invoked by make to run the proof."""
+
+    return run(['make', '-nB'], cwd=proof)
+
+def extract_viewer_command(commands):
+    """Extract the invocation of cbmc-viewer from the commands invoked by make.
+    """
+
+    commands = [extract_command_from_litani_command(cmd) for cmd in commands]
+    viewer_commands = [cmd for cmd in commands if is_viewer_command(cmd)]
+    if len(viewer_commands) != 1:
+        logging.debug("Unexpected list of cbmc-viewer commands: %s",
+                      viewer_commands)
+        return None
+
+    return viewer_commands[0]
+
+def get_viewer_command_from_make(proof=None):
+
+    # This function will fail with the starter kit.
+    #
+    # The stater kit runs cbmc-viewer by pushing a variable VIEWER_CMD
+    # to the environment and running litani with '--command $VIEWER_CMD'.
+    # The make output includes this command with the variable unexpanded.
+
+    command = extract_viewer_command(get_make_commands(proof))
+    if not command:
+        logging.info("Can't find cbmc-viewer command in make output.")
+        return None
+
+    return command
+
+def get_viewer_command_from_litani(proofdir):
+
+    # Litani output is written to a directory named 'output' in the
+    # current working directory.  This output includes a file with
+    # a name like
+    #   output/litani/runs/36c0b562-7535-4ff5-94be-bae5459ba6d2/run.json
+    # that includes all commands run by litani, including the fully
+    # expanded invocation of cbmc-viewer.
+
+    try:
+        runs = run(['find', 'output', '-name', 'run.json'], cwd=proofdir)
+        if not runs:
+            logging.info("Can't find cbmc-viewer command in litani output.")
+            return None
+    except: # pylint: disable=bare-except
+        logging.info("Can't find cbmc-viewer command in litani output: "
+                     "can't find litani output.")
+        return None
+
+    with open(os.path.join(proofdir, runs[0]), encoding="utf-8") as handle:
+        log = json.load(handle)
+
+    cmd = log['pipelines'][0]['ci_stages'][-1]['jobs'][0]['wrapper_arguments']['command'] # pylint: disable=line-too-long
+    cmd = strip_whitespace(cmd)
+    assert cmd.startswith('cbmc-viewer')
+    return cmd
+
+def get_viewer_command(proofdir, proof):
+
+    return (
+        get_viewer_command_from_make(os.path.join(proofdir, proof)) or
+        get_viewer_command_from_litani(proofdir)
+    )
+
+################################################################
+# Extract flags from a cbmc-viewer command
+
+def extract_viewer_flag(flag, command):
+    try:
+        words = command.strip().split()
+        index = words.index(flag)
+        return os.path.normpath(words[index+1])
+    except ValueError:
+        logging.debug("Can't find flag %s in command %s", flag, command)
+    except IndexError:
+        logging.debug("Can't find flag %s argument in command %s",
+                      flag, command)
+    return None
+
+def extract_srcdir(command):
+    return extract_viewer_flag('--srcdir', command)
+
+def extract_reportdir(command):
+    return (
+        extract_viewer_flag('--reportdir', command) # Viewer 2.0
+        or
+        extract_viewer_flag('--htmldir', command)   # Viewer 1.0 legacy
+    )
+
+################################################################
+# Find paths to viewer-results.json summaries produced by cbmc-viewer
+
+def viewer_result_paths(args):
+
+    # Find all copies of viewer-result.json under the proof directory
+    cmd = ['find', '.', '-name', args.viewer_result]
+    viewer_results = run(cmd, cwd=args.proofdir)
+
+    # Clean up find output
+    viewer_results = [os.path.normpath(result) for result in viewer_results]
+
+    # Ignore litani copies of viewer-result.json
+    viewer_results = [result for result in viewer_results
+                      if not result.startswith('output/latest')
+                      and not result.startswith('output/litani/runs')]
+
+    return viewer_results
+
+################################################################
+# Guess missing flags from paths to viewer-result.json
+
+def guess_proof_from_result_paths(args, result_paths):
+
+    if args.proof: # don't guess, already defined
+        return args.proof
+
+    # CBMC viewer puts viewer-result.json under report/json in every
+    # proof directory where report is the value of the --reportdir
+    # flag to viewer.
+    #
+    # Assume the directory three levels above viewer-result.json is a
+    # proof directory.
+
+    proofs = [
+        os.path.normpath(
+            os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.normpath(result_path)))))
+        for result_path in result_paths]
+    proofs = sorted(set(proofs))
+
+    assert len(proofs) > 0
+    return proofs
+
+def guess_jsonpath_from_result_paths(args, result_paths):
+
+    if args.jsonpath: # don't guess, already defined
+        return args.jsonpath
+
+    # CBMC viewer puts viewer-result.json under report/json in every
+    # proof directory where report is the value of the --reportdir
+    # flag to viewer.
+    #
+    # Assume the directory two levels above viewer-result.json is reportdir.
+
+    reportdirs = [
+        os.path.normpath(
+            os.path.basename(os.path.dirname(os.path.dirname(
+                os.path.normpath(result_path)))))
+        for result_path in result_paths]
+    reportdirs = sorted(set(reportdirs))
+
+    assert len(reportdirs) == 1
+    reportdir = reportdirs[0]
+
+    return os.path.normpath(os.path.join(reportdir, 'json'))
+
+################################################################
+# Guess missing flags from flags to cbmc-viewer command
+
+def guess_jsonpath_from_viewer_command(args, viewer_command):
+
+    if args.jsonpath: # don't guess, already defined
+        return args.jsonpath
+
+    reportdir = extract_reportdir(viewer_command)
+    if not reportdir:
+        return args.jsonpath
+
+    return os.path.normpath(os.path.join(reportdir, 'json'))
+
+def guess_srcdir_from_viewer_command(args, viewer_command):
+
+    if args.srcdir: # don't guess, already defined
+        return args.srcdir
+
+    assert len(args.proof) > 0 # validated by guess_proof()
+    proof = [args.proofdir, args.proof[0]]
+
+    viewer_command = get_viewer_command(*proof)
+    if not viewer_command:
+        logging.info("Can't guess srcdir: cbmc-viewer command not found.")
+        return args.cbmcpath
+
+    srcdir = extract_srcdir(viewer_command)
+    if not srcdir:
+        logging.info("Can't guess srcdir: "
+                     "--srcdir not found in cbmc-viewer command: %s",
+                     viewer_command)
+        return args.cbmcpath
+
+    return os.path.abspath(srcdir)
+
+################################################################
+# Guess flags from other arguments
+
+def guess_cbmcpath_from_args(args):
+
+    if args.cbmcpath: # don't guess, already defined
+        return args.cbmcpath
+
+    # Guess cbmcpath from srcdir and proofdir
+    if not args.srcdir:
+        logging.info("Can't guess cbmcpath: srcdir is empty.")
+        return args.cbmcpath
+    if not args.proofdir:
+        logging.info("Can't guess cbmcpath: proofdir is empty.")
+        return args.cbmcpath
+
+    # Guess that cbmcdir is the parent of proofdir, and guess that
+    # cbmcpath is the path from srcdir to cbmcdir.
+    proofdir = os.path.abspath(args.proofdir)
+    srcdir = os.path.abspath(args.srcdir)
+    cbmcpath = os.path.relpath(os.path.dirname(proofdir), srcdir)
+
+    if cbmcpath.startswith('..'):
+        logging.info("Can't guess cbmcpath: "
+                     "srcdir %s does not contain proofdir %s",
+                     srcdir, proofdir)
+        return args.cbmcpath
+
+    return cbmcpath
+
+################################################################
+# Compute  histogram
+
+def defined_histogram(summary, key='stubbed'):
+    histogram_by_name = {}
+    for proof, proof_summary in summary.items():
+        for _, stubbed_functions in proof_summary[key].items():
+            for stub in stubbed_functions:
+                histogram_by_name[stub] = histogram_by_name.get(stub, [])
+                histogram_by_name[stub].append(proof)
+
+    counts = [(stub, len(users)) for stub, users in histogram_by_name.items()]
+    counts = sorted(counts, key=lambda pair: (pair[1], pair[0]), reverse=True)
+    histogram_by_count = {pair[0]: pair[1] for pair in counts}
+
+    return {"name": histogram_by_name, "count": histogram_by_count}
+
+def undefined_histogram(summary, key):
+    histogram_by_name = {}
+    for proof, proof_summary in summary.items():
+        for undefined in proof_summary[key]:
+            histogram_by_name[undefined] = histogram_by_name.get(undefined, [])
+            histogram_by_name[undefined].append(proof)
+
+    counts = [(func, len(users)) for func, users in histogram_by_name.items()]
+    counts = sorted(counts, key=lambda pair: (pair[1], pair[0]), reverse=True)
+    histogram_by_count = {pair[0]: pair[1] for pair in counts}
+
+    return {"name": histogram_by_name, "count": histogram_by_count}
+
+
+################################################################
+
+def compute_default_arguments(args):
+
+    # Ensure absolute paths to important directories
+    if args.proofdir:
+        args.proofdir = os.path.abspath(args.proofdir)
+    if args.srcdir:
+        args.srcdir = os.path.abspath(args.srcdir)
+    if args.proof:
+        args.proof = [os.path.normpath(proof) for proof in args.proof]
+
+    assert args.proofdir
+    result_paths = viewer_result_paths(args)
+    args.proof = guess_proof_from_result_paths(args, result_paths)
+    args.jsonpath = guess_jsonpath_from_result_paths(args, result_paths)
+
+    assert args.proofdir
+    assert args.proof
+    viewer_command = get_viewer_command(args.proofdir, args.proof[0])
+    args.jsonpath = guess_jsonpath_from_viewer_command(args, viewer_command)
+    args.srcdir = guess_srcdir_from_viewer_command(args, viewer_command)
+
+    args.cbmcpath = guess_cbmcpath_from_args(args)
+
+    return args
+
+def log_arguments(args, text=''):
+    label = ' '.join(['ARG', text]).strip()
+    for arg in dir(args):
+        if not arg.startswith('_'):
+            logging.info('%s: %s: %s', label, arg, getattr(args, arg))
+
+
+def main():
+    args = parse_arguments()
+    configure_logger(args.verbose, args.debug)
+    log_arguments(args)
+
+    args = compute_default_arguments(args)
+    log_arguments(args)
+
+    summary = scan_proofs(args.proof, args)
+    if args.stubbed_usage:
+        print(json.dumps(defined_histogram(summary, 'stubbed'), indent=2))
+        return
+    if args.removed_usage:
+        print(json.dumps(undefined_histogram(summary, 'removed'), indent=2))
+        return
+    if args.missing_usage:
+        print(json.dumps(undefined_histogram(summary, 'missing'), indent=2))
+        return
+    print(json.dumps(summary, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+import csv
+import argparse
+import logging
+import sys
+import subprocess
+import os
+import json
+
+import stubs
+
+################################################################
+
+def create_parser():
+    desc = "Summarize stubs and undefined functions in proof repositories."
+    args = [
+        {
+            "flag": "--github",
+            "default": "projects.json",
+            "help": "JSON file defining proof projects and repositories "
+                    "(default: %(default)s)"
+        },
+        {
+            "flag": "--project",
+            "nargs": "*",
+            "default": [],
+            "help": "Names of proof projects to summarize "
+                    "(default: all projects)"
+        },
+        {
+            "flag": "--clean",
+            "action": "store_true",
+            "help": "Remove proof results and proof summaries"
+        },
+        {
+            "flag": "--clone",
+            "action": "store_true",
+            "help": "Clone proof project"
+        },
+        {
+            "flag": "--build",
+            "action": "store_true",
+            "help": "Build proof project (run proofs)"
+        },
+        {
+            "flag": "--summarize",
+            "action": "store_true",
+            "help": "Summarize project proof results"
+        },
+        {
+            "flag": "--chart",
+            "action": "store_true",
+            "help": "Write project summary data as JSON to stdout"
+        },
+        {
+            "flag": "--verbose",
+            "action": "store_true",
+            "help": "Verbose output"
+        },
+        {
+            "flag": "--debug",
+            "action": "store_true",
+            "help": "Debug output"
+        }
+    ]
+    epilog = None
+
+    parser = argparse.ArgumentParser(description=desc, epilog=epilog)
+    for arg in args:
+        flag = arg['flag']
+        del arg['flag']
+        parser.add_argument(flag, **arg)
+    return parser
+
+def parse_arguments():
+    return create_parser().parse_args()
+
+def configure_logger(verbose=False, debug=False):
+    # Logging is configured by the first invocation of logging.basicConfig
+    fmt = '%(levelname)s: %(message)s'
+    if debug:
+        logging.basicConfig(level=logging.DEBUG, format=fmt)
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format=fmt)
+    logging.basicConfig(format=fmt)
+
+################################################################
+# Shell out commands
+
+def run(cmd, cwd=None, encoding=None):
+    """Run a command in a subshell and return the standard output."""
+
+    kwds = {
+        'cwd': cwd,
+    }
+    if sys.version_info >= (3, 6): # encoding introduced in Python 3.6
+        kwds['encoding'] = encoding
+
+    logging.debug("Running %s", ' '.join(cmd))
+    result = subprocess.run(cmd, **kwds, check=False)
+    if result.returncode:
+        logging.debug('Failed command: %s', ' '.join(cmd))
+        result.check_returncode()
+
+################################################################
+#
+
+def clean_project(project_path):
+    if not os.path.isdir(project_path):
+        logging.info('%s does not exist: not cleaning %s',
+                     project_path, project_path)
+        return
+
+    logging.info('Cleaning %s', project_path)
+    run(['git', 'clean', '-fdx'], cwd=project_path)
+    run(['git', 'checkout', '.'], cwd=project_path)
+
+def clone_project(project_url):
+    project_path = os.path.basename(project_url)
+
+    if os.path.isdir(project_path):
+        logging.info('%s exists: not cloning %s into %s',
+                     project_path, project_url, project_path)
+        return project_path
+
+    logging.info('Cloning %s into %s', project_url, project_path)
+    run(['git', 'clone', project_url])
+    run(['git', 'submodule', 'update', '--init', '--checkout', '--recursive'],
+        cwd=project_path)
+
+    return project_path
+
+def build_project(project_path, proofs_path):
+
+    if not os.path.isdir(project_path):
+        logging.info('%s does not exist: not running proofs in project %s',
+                     project_path, project_path)
+        return
+
+    path = os.path.join(project_path, proofs_path)
+
+    logging.info('Running %s proofs in %s', project_path, path)
+    run(['./run-cbmc-proofs.py'], cwd=path)
+
+def summarize_project(project_path, proofs_path):
+    if not os.path.isdir(project_path):
+        logging.info('%s does not exist: not summarizing project %s',
+                     project_path, project_path)
+        return None
+
+    path = os.path.join(project_path, proofs_path)
+
+    # Simulate invocation of summary script until args removed from script API
+    args = stubs.parse_arguments(
+        ['--srcdir', project_path, '--proofdir', path]
+    )
+    args = stubs.compute_default_arguments(args)
+
+    summary = stubs.scan_proofs(args.proof, args)
+    stubbed = stubs.defined_histogram(summary, 'stubbed')
+    removed = stubs.undefined_histogram(summary, 'removed')
+    missing = stubs.undefined_histogram(summary, 'missing')
+
+    return {
+        'stubbed': stubbed,
+        'removed': removed,
+        'missing': missing
+    }
+
+################################################################
+#
+
+def chart_projects_csv(summary):
+    # pylint: disable = line-too-long
+    writer = csv.writer(sys.stdout)
+    writer.writerow([''] + list(summary))
+    writer.writerow([])
+    writer.writerow(['stubbed'] + [len(summary[project]['stubbed']['count'] or []) for project in summary])
+    writer.writerow(['removed'] + [len(summary[project]['removed']['count'] or []) for project in summary])
+    writer.writerow(['missing'] + [len(summary[project]['missing']['count'] or []) for project in summary])
+    writer.writerow([])
+    writer.writerow(['stubbed audited'] + [0 for project in summary])
+    writer.writerow(['removed audited'] + [0 for project in summary])
+    writer.writerow(['missing audited'] + [0 for project in summary])
+    writer.writerow([])
+    writer.writerow(['stubbed issues'] + [0 for project in summary])
+    writer.writerow(['removed issues'] + [0 for project in summary])
+    writer.writerow(['missing issues'] + [0 for project in summary])
+    writer.writerow([])
+    writer.writerow(['stubbed unaudited'] + [len(summary[project]['stubbed']['count'] or []) for project in summary])
+    writer.writerow(['removed unaudited'] + [len(summary[project]['removed']['count'] or []) for project in summary])
+    writer.writerow(['missing unaudited'] + [len(summary[project]['missing']['count'] or []) for project in summary])
+
+def chart_projects_json(summary):
+    result = {}
+
+    for project in summary:
+        data = summary[project]
+        result[project] = {
+            "stubbed": sorted(data['stubbed']['count']),
+            "removed": sorted(data['removed']['count']),
+            "missing": sorted(data['missing']['count']),
+            "stubbed-audited": [],
+            "removed-audited": [],
+            "missing-audited": [],
+            "stubbed-issues": [],
+            "removed-issues": [],
+            "missing-issues": [],
+            "stubbed-resolved": [],
+            "removed-resolved": [],
+            "missing-resolved": [],
+        }
+    return json.dumps(result, indent=2)
+
+################################################################
+#
+
+def main():
+    args = parse_arguments()
+    args.project = [os.path.normpath(project) for project in args.project]
+
+    configure_logger(args.verbose, args.debug)
+
+    with open(args.github, encoding="utf-8") as handle:
+        github = json.load(handle)
+
+    summary = {}
+
+    if not args.project:
+        args.project = list(github)
+
+    for project in args.project:
+        project_repo = github[project]['github']
+        proofs_path = github[project]['proofs']
+        project_path = os.path.basename(project_repo)
+        if args.clean:
+            clean_project(project_path)
+        if args.clone:
+            clone_project(project_repo)
+        if args.build:
+            build_project(project_path, proofs_path)
+        if args.summarize or args.chart:
+            result = summarize_project(project_path, proofs_path)
+            if result:
+                summary[project] = result
+
+    if args.summarize:
+        print(json.dumps(summary, indent=2))
+
+    if args.chart:
+#        chart_projects_csv(summary)
+        print(chart_projects_json(summary))
+
+if __name__ == "__main__":
+    main()

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -249,7 +249,6 @@ def main():
         print(json.dumps(summary, indent=2))
 
     if args.chart:
-#        chart_projects_csv(summary)
         print(chart_projects_json(summary))
 
 if __name__ == "__main__":


### PR DESCRIPTION
This directory contains a script that scans the viewer output for a set of and produce a summary of the stubs and undefined functions being used in the proofs.  This is a work-in-progress, and will ultimately be incorporated into viewer and litani.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
