### PR TITLE
Set jinja to autoescape html.

### DIFF
--- a/cbmc_viewer/templates.py
+++ b/cbmc_viewer/templates.py
@@ -25,7 +25,10 @@ def env():
     if ENV is None:
         template_dir = pkg_resources.resource_filename(PACKAGE, TEMPLATES)
         ENV = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(template_dir)
+            loader=jinja2.FileSystemLoader(template_dir),
+            autoescape=jinja2.select_autoescape(
+                enabled_extensions=('html'),
+                default_for_string=True)
         )
     return ENV
 


### PR DESCRIPTION
Set jinja to autoescape the content written to html via jinja templates.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
