### PR TITLE
Add compare-trace command

### DIFF
--- a/cbmc_viewer/tracet.py
+++ b/cbmc_viewer/tracet.py
@@ -555,7 +555,7 @@ def parse_json_assignment(step, root=None):
         raise UserWarning("Unknown json assignment type: {}".format(akind))
 
     # &v is represented as {name: pointer, data: v}
-    # NULL is represented as {name: pointer, data: {((basetype *)NULL)}
+    # NULL is represented as {name: pointer, data: {((basetype *)NULL)}}
     data = step['value'].get('data')
     if step['value'].get('name') == 'pointer' and data and 'NULL' not in data:
         data = '&{}'.format(data)

--- a/cbmc_viewer/tracet.py
+++ b/cbmc_viewer/tracet.py
@@ -376,7 +376,7 @@ def parse_xml_step(step, root=None):
 
     if parser is None:
         # skip uninteresting kinds of steps
-        if kind in ['loop-head']:
+        if kind == 'loop-head':
             logging.debug('Skipping step type: %s', kind)
             return None
 
@@ -518,7 +518,7 @@ def parse_json_step(step, root=None):
               parse_json_location_only if kind == 'location-only' else None)
     if parser is None:
         # skip uninteresting kinds of steps
-        if kind in ['loop-head']:
+        if kind == 'loop-head':
             logging.debug('Skipping step type: %s', kind)
             return None
 

--- a/tests/compare-result
+++ b/tests/compare-result
@@ -45,7 +45,9 @@ def clean_status(result):
           # Ignore status lines with embedded path names
           not line.startswith('Unwinding loop') and
           not line.startswith('aborting path') and
-          not line.startswith('Not unwinding loop')
+          not line.startswith('Not unwinding loop') and
+          # Ignore line emitted by json and xml but not text
+          not line.startswith('Building error trace')
     ]
     return result
 

--- a/tests/compare-trace
+++ b/tests/compare-trace
@@ -1,0 +1,74 @@
+#! /usr/bin/env python3
+
+# Set emacs mode to Python
+# -*- mode: Python;-*-
+
+"""Compare make-trace output ignoring known variations in cbmc output."""
+
+import argparse
+import json
+
+def parse_arguments():
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=
+        'Compare make-trace output ignoring known variations in cbmc output.'
+    )
+    parser.add_argument(
+        'TRACE1',
+        help='make-trace output'
+    )
+    parser.add_argument(
+        'TRACE2',
+        help='make-trace output'
+    )
+    return parser.parse_args()
+
+def clean_step_detail(detail):
+    """Clean up step details."""
+
+    for key in ["lhs-lexical-scope", "rhs-binary", "rhs-value"]:
+        if key in detail:
+            del detail[key]
+    return detail
+
+def clean_step(step):
+    """Clean up a step."""
+
+    step["detail"] = clean_step_detail(step["detail"])
+    return step
+
+def clean_trace(trace):
+    """Clean up a trace."""
+
+    return [clean_step(step) for step in trace]
+
+def clean_traces(data):
+    """Clean up traces in output of make-traces."""
+
+    data["viewer-trace"]["traces"] = {
+        name: clean_trace(trace) for name, trace in data["viewer-trace"]["traces"].items()
+    }
+    return data
+
+def main():
+    """Compare make-trace output."""
+
+    args = parse_arguments()
+    with open(args.TRACE1, encoding='utf-8') as handle:
+        trace1 = clean_traces(json.load(handle))
+    with open(args.TRACE2, encoding='utf-8') as handle:
+        trace2 = clean_traces(json.load(handle))
+
+    with open('/tmp/trace1.json', "w", encoding='utf-8') as handle:
+        json.dump(trace1, handle, indent=2)
+    with open('/tmp/trace2.json', "w", encoding='utf-8') as handle:
+        json.dump(trace2, handle, indent=2)
+
+    if trace1 != trace2:
+        raise UserWarning(
+            f"make-trace output differs: {args.TRACE1} {args.TRACE2}"
+        )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request consists of three commits making three changes:

* Modifies the trace summary produced by make-trace on cbmc json output to more closely match the trace summary produced on cbmc json output 
* Adds a compare-trace command to compare two trace summaries (ignoring known discrepancies between cbmc json and xml output).
* Modifies the compare-result command to ignore a minor, known discrepancy between cbmc text and cbmc json/xml output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
