### PR TITLE
Fix interpretation of basic block coverage descriptions

### DIFF
--- a/cbmc_viewer/coveraget.py
+++ b/cbmc_viewer/coveraget.py
@@ -499,6 +499,9 @@ def parse_basic_block(basic_block):
 def parse_chunk(chunk):
     """Parse a chunk of coverage"""
 
+    # cbmc has added whitespace to coverage descriptions
+    chunk = chunk.strip()
+
     # The chunk has the form FILE:FUNCTION:LINES
     # Don't use split in order to allow FUNCTION to contain ':'
     first_colon, last_colon = chunk.find(':'), chunk.rfind(':')

--- a/cbmc_viewer/srcloct.py
+++ b/cbmc_viewer/srcloct.py
@@ -215,3 +215,13 @@ def xml_srcloc(cbmc_srcloc, root=None):
     )
 
 ################################################################
+
+def json_srcloc_wkdir(cbmc_srcloc):
+    """Extract working directory from a json source location"""
+    return cbmc_srcloc.get('workingDirectory')
+
+def xml_srcloc_wkdir(cbmc_srcloc):
+    """Extract working directory from an xml source location"""
+    return cbmc_srcloc.get('working-directory')
+
+################################################################


### PR DESCRIPTION
This pull request fixes the interpretation of basic block coverage descriptions.  The current implementation is correct only if all source locations contributing to a basic block come from the same file, but this is false when the basic block includes code inlined from multiple files.

Review this pull request commit by commit.  The commits are organized to make this easy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
