### PR TITLE
Better clean up for 'make unpip' and 'make uninstall'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ pip:
 
 unpip:
 	./setup.py clean --all
-	$(RM) -r dist cbmc_viewer.egg-info
+	$(RM) -r build cbmc_viewer.egg-info dist 
 
 ################################################################
 
@@ -64,7 +64,7 @@ undevelop:
 install: pip
 	cd .. && sudo python3 -m pip install $(abspath dist/cbmc_viewer-*-py3-none-any.whl)
 
-uninstall:
+uninstall: unpip
 	cd .. && sudo python3 -m pip uninstall -y cbmc-viewer
 
 ################################################################

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Package set up script for cbmc-viewer."""
+"""The setuptools packaging script for cbmc-viewer."""
 
 import setuptools
 


### PR DESCRIPTION
This commit causes 'make unpip' clean up completely after 'make pip', and causes 'make uninstall' clean up completely after 'make install'.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
