### PR TITLE
fix: Re-enable Jinja2 autoescaping of HTML using a different way

### DIFF
--- a/cbmc_viewer/templates.py
+++ b/cbmc_viewer/templates.py
@@ -4,6 +4,7 @@
 """Jinja templates."""
 
 import jinja2
+from jinja2 import select_autoescape
 
 import pkg_resources
 
@@ -26,7 +27,7 @@ def env():
         template_dir = pkg_resources.resource_filename(PACKAGE, TEMPLATES)
         ENV = jinja2.Environment(
             loader=jinja2.FileSystemLoader(template_dir),
-            autoescape=jinja2.select_autoescape(
+            autoescape=select_autoescape(
                 enabled_extensions=('html'),
                 default_for_string=True)
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I'm re-enabling the existing autoescaping of HTML for Jinja2 templates in a different way

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
