### PR TITLE
Apply visible_steps to individual text traces

### DIFF
--- a/src/cbmc_viewer/tracet.py
+++ b/src/cbmc_viewer/tracet.py
@@ -221,11 +221,11 @@ def parse_text_traces(textfile, root=None, wkdir=None):
             continue
         if block.startswith('** '):
             if name:
-                traces[name] = trace
+                traces[name] = list(visible_steps(trace))
             break
         raise UserWarning("Unknown block: {}".format(block))
 
-    return list(visible_steps(traces))
+    return traces
 
 def parse_text_assignment(string):
     """Parse an assignment in a text trace."""


### PR DESCRIPTION
A prior commit added a visible_steps generator to modify which steps
in a trace are considered visible and to omit the remaining hidden
steps from the trace.  That commit incorrectly applied the generator
to the dict mapping trace names to traces, rather than to the traces
themselves.  This commit repairs that error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
